### PR TITLE
自動スクロール同期、TopBar/URLトグル連携、MarkdownPreview行属性と過去日/件数、Itineraryリンク

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useMemo } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 import { ImportDialog } from './components/dialog/ImportDialog';
 import { LoadSampleDialog } from './components/dialog/LoadSampleDialog';
 import { Header } from './components/Header';
@@ -25,6 +25,7 @@ const PREVIEW_DEBOUNCE_DELAY = 300;
 
 function App() {
     const tzSelectId = useId();
+    const [editedLine, setEditedLine] = useState<number | undefined>(undefined);
 
     const { content, setContent, pendingLoadSample, loadSample, cancelLoadSample, confirmLoadSample } = useInitialContent({
         storageKey: STORAGE_KEY,
@@ -56,8 +57,9 @@ function App() {
             currency: topbar.currency,
             stayMode: topbar.stayMode,
             showPast: topbar.showPast,
+            autoScroll: topbar.autoScroll,
         }),
-        [topbar.timezone, topbar.currency, topbar.stayMode, topbar.showPast]
+        [topbar.timezone, topbar.currency, topbar.stayMode, topbar.showPast, topbar.autoScroll]
     );
 
     const latestContent = useLatest(content);
@@ -113,7 +115,14 @@ function App() {
                         <div className={`${topbar.viewMode === 'split' ? 'md:basis-1/2 basis-1/3' : 'flex-1'} min-w-0 min-h-0`}>
                             <div className="px-2 py-1 bg-gray-100 border-b border-gray-300 font-medium text-sm text-gray-600">Editor</div>
                             <div className="h-[calc(100%-41px)] min-h-0">
-                                <MonacoEditor value={content} onChange={handleContentChange} onSave={saveNow} />
+                                <MonacoEditor
+                                    value={content}
+                                    onChange={handleContentChange}
+                                    onSave={saveNow}
+                                    onCursorLineChange={(ln) => {
+                                        if (topbar.autoScroll) setEditedLine(ln);
+                                    }}
+                                />
                             </div>
                         </div>
                     )}
@@ -122,7 +131,7 @@ function App() {
                             <div className="px-2 py-1 bg-gray-100 border-b border-gray-300 font-medium text-sm text-gray-600">Preview</div>
                             <div className="h-[calc(100%-41px)] min-h-0">
                                 <MarkdownPreviewErrorBoundary>
-                                    <MarkdownPreview content={previewContent} {...previewProps} title={frontmatterTitle} summary={summary} totalFormatted={totalFormatted} breakdownFormatted={breakdownFormatted} />
+                                    <MarkdownPreview content={previewContent} {...previewProps} title={frontmatterTitle} summary={summary} totalFormatted={totalFormatted} breakdownFormatted={breakdownFormatted} activeLine={editedLine} />
                                 </MarkdownPreviewErrorBoundary>
                             </div>
                         </div>

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -55,8 +55,9 @@ function App() {
             timezone: topbar.timezone,
             currency: topbar.currency,
             stayMode: topbar.stayMode,
+            showPast: topbar.showPast,
         }),
-        [topbar.timezone, topbar.currency, topbar.stayMode]
+        [topbar.timezone, topbar.currency, topbar.stayMode, topbar.showPast]
     );
 
     const latestContent = useLatest(content);

--- a/apps/studio/src/components/MarkdownPreview.tsx
+++ b/apps/studio/src/components/MarkdownPreview.tsx
@@ -30,6 +30,21 @@ interface MarkdownPreviewProps {
     activeLine?: number;
 }
 
+// Remove internal props passed by react-markdown that should not hit the DOM
+const omitInternalProps = (props: Record<string, unknown>): Record<string, unknown> => {
+    const clean = { ...(props as Record<string, unknown>) } as Record<string, unknown> & {
+        node?: unknown;
+        sourcePosition?: unknown;
+        index?: unknown;
+        siblingCount?: unknown;
+    };
+    delete (clean as { node?: unknown }).node;
+    delete (clean as { sourcePosition?: unknown }).sourcePosition;
+    delete (clean as { index?: unknown }).index;
+    delete (clean as { siblingCount?: unknown }).siblingCount;
+    return clean as Record<string, unknown>;
+};
+
 const WarnEffect: React.FC<{ message?: string }> = ({ message }) => {
     React.useEffect(() => {
         if (message) notifyError(message);
@@ -115,6 +130,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                         const { children, ...rest } = (props as { children?: React.ReactNode }) || {};
                         const dataItinDate = getDataAttr(rest as Record<string, unknown>, 'data-itin-date');
                         const warnHeadingTz = getDataAttr(rest as Record<string, unknown>, 'data-itin-warn-date-tz');
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
                         const parsed = tryParseJson<{
                             date: string;
                             timezone?: string;
@@ -125,7 +141,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                             if (!showPastEffective && isPastDay(parsed.date, parsed.timezone)) {
                                 const cnt = eventsCountByDate[parsed.date] || 0;
                                 return (
-                                    <div className="flex items-center text-gray-500 text-xs mt-6 mb-4" {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
+                                    <div className="flex items-center text-gray-500 text-xs mt-6 mb-4" {...(cleanRest as React.HTMLAttributes<HTMLDivElement>)}>
                                         <span className="flex-1 border-t border-gray-200" />
                                         <span className="px-2">{cnt} past events hidden</span>
                                         <span className="flex-1 border-t border-gray-200" />
@@ -133,14 +149,14 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                                 );
                             }
                             return (
-                                <div className="contents" {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
+                                <div className="contents" {...(cleanRest as React.HTMLAttributes<HTMLDivElement>)}>
                                     <WarnEffect message={warnHeadingTz ? `Heading timezone "${warnHeadingTz}" is invalid. Using fallback.` : undefined} />
                                     <Heading date={parsed.date} timezone={parsed.timezone} prevStayName={stayMode === 'header' ? parsed.prevStayName : undefined} />
                                 </div>
                             );
                         }
                         return (
-                            <h2 {...(rest as React.HTMLAttributes<HTMLHeadingElement>)} className="text-2xl font-semibold text-blue-700 border-b-2 border-blue-200 pb-3 mt-8 mb-6">
+                            <h2 {...(cleanRest as React.HTMLAttributes<HTMLHeadingElement>)} className="text-2xl font-semibold text-blue-700 border-b-2 border-blue-200 pb-3 mt-8 mb-6">
                                 {children}
                             </h2>
                         );
@@ -155,6 +171,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                         const dateStr = getDataAttr(rest as Record<string, unknown>, 'data-itin-date-str');
                         const dateTz = getDataAttr(rest as Record<string, unknown>, 'data-itin-date-tz');
                         const warnEventTz = getDataAttr(rest as Record<string, unknown>, 'data-itin-warn-event-tz');
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
                         if (skip === '1') return null;
                         if (!showPastEffective && dateStr && isPastDay(dateStr, dateTz)) return null;
                         const rawEvent = tryParseJson<unknown>(eventStr);
@@ -184,14 +201,14 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                             }
                             const eventData = r as Parameters<typeof Item>[0]['eventData'];
                             return (
-                                <div className="contents" {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
+                                <div className="contents" {...(cleanRest as React.HTMLAttributes<HTMLDivElement>)}>
                                     <WarnEffect message={warnMessage} />
                                     <Item eventData={eventData} dateStr={dateStr} timezone={displayTimezone} currency={currency} />
                                 </div>
                             );
                         }
                         return (
-                            <p {...(rest as React.HTMLAttributes<HTMLParagraphElement>)} className="mb-4 leading-relaxed text-gray-800 ml-20">
+                            <p {...(cleanRest as React.HTMLAttributes<HTMLParagraphElement>)} className="mb-4 leading-relaxed text-gray-800 ml-20">
                                 {children}
                             </p>
                         );
@@ -199,37 +216,44 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                     ul: (props: unknown) => {
                         const { children, ...rest } = (props as { children?: React.ReactNode } & Record<string, unknown>) || {};
                         if (shouldHideByDateAttr(rest as Record<string, unknown>)) return null;
-                        return <ul {...(rest as React.HTMLAttributes<HTMLUListElement>)}>{children}</ul>;
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
+                        return <ul {...(cleanRest as React.HTMLAttributes<HTMLUListElement>)}>{children}</ul>;
                     },
                     ol: (props: unknown) => {
                         const { children, ...rest } = (props as { children?: React.ReactNode } & Record<string, unknown>) || {};
                         if (shouldHideByDateAttr(rest as Record<string, unknown>)) return null;
-                        return <ol {...(rest as React.HTMLAttributes<HTMLOListElement>)}>{children}</ol>;
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
+                        return <ol {...(cleanRest as React.HTMLAttributes<HTMLOListElement>)}>{children}</ol>;
                     },
                     li: (props: unknown) => {
                         const { children, ...rest } = (props as { children?: React.ReactNode } & Record<string, unknown>) || {};
                         if (shouldHideByDateAttr(rest as Record<string, unknown>)) return null;
-                        return <li {...(rest as React.HTMLAttributes<HTMLLIElement>)}>{children}</li>;
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
+                        return <li {...(cleanRest as React.HTMLAttributes<HTMLLIElement>)}>{children}</li>;
                     },
                     blockquote: (props: unknown) => {
                         const { children, ...rest } = (props as { children?: React.ReactNode } & Record<string, unknown>) || {};
                         if (shouldHideByDateAttr(rest as Record<string, unknown>)) return null;
-                        return <blockquote {...(rest as React.HTMLAttributes<HTMLQuoteElement>)}>{children}</blockquote>;
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
+                        return <blockquote {...(cleanRest as React.HTMLAttributes<HTMLQuoteElement>)}>{children}</blockquote>;
                     },
                     table: (props: unknown) => {
                         const { children, ...rest } = (props as { children?: React.ReactNode } & Record<string, unknown>) || {};
                         if (shouldHideByDateAttr(rest as Record<string, unknown>)) return null;
-                        return <table {...(rest as React.HTMLAttributes<HTMLTableElement>)}>{children}</table>;
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
+                        return <table {...(cleanRest as React.HTMLAttributes<HTMLTableElement>)}>{children}</table>;
                     },
                     pre: (props: unknown) => {
                         const { children, ...rest } = (props as { children?: React.ReactNode } & Record<string, unknown>) || {};
                         if (shouldHideByDateAttr(rest as Record<string, unknown>)) return null;
-                        return <pre {...(rest as React.HTMLAttributes<HTMLPreElement>)}>{children}</pre>;
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
+                        return <pre {...(cleanRest as React.HTMLAttributes<HTMLPreElement>)}>{children}</pre>;
                     },
                     hr: (props: unknown) => {
                         const { ...rest } = (props as Record<string, unknown>) || {};
                         if (shouldHideByDateAttr(rest as Record<string, unknown>)) return null;
-                        return <hr {...(rest as React.HTMLAttributes<HTMLHRElement>)} />;
+                        const cleanRest = omitInternalProps(rest as Record<string, unknown>);
+                        return <hr {...(cleanRest as React.HTMLAttributes<HTMLHRElement>)} />;
                     },
                 }}
             >

--- a/apps/studio/src/components/MonacoEditor.tsx
+++ b/apps/studio/src/components/MonacoEditor.tsx
@@ -1,5 +1,5 @@
 import Editor from '@monaco-editor/react';
-import { type FC, memo } from 'react';
+import { type FC, memo, useEffect, useRef } from 'react';
 
 interface MonacoEditorProps {
     value: string;
@@ -10,6 +10,17 @@ interface MonacoEditorProps {
 }
 
 const MonacoEditorComponent: FC<MonacoEditorProps> = ({ value, onChange, onSave, onCursorLineChange, onChangedLines }) => {
+    const cursorLineChangeRef = useRef<MonacoEditorProps['onCursorLineChange']>();
+    const changedLinesRef = useRef<MonacoEditorProps['onChangedLines']>();
+
+    useEffect(() => {
+        cursorLineChangeRef.current = onCursorLineChange;
+    }, [onCursorLineChange]);
+
+    useEffect(() => {
+        changedLinesRef.current = onChangedLines;
+    }, [onChangedLines]);
+
     const handleEditorChange = (value: string | undefined) => {
         onChange(value || '');
     };
@@ -26,32 +37,31 @@ const MonacoEditorComponent: FC<MonacoEditorProps> = ({ value, onChange, onSave,
                     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
                         onSave();
                     });
-                    if (onCursorLineChange) {
-                        // 初期行を通知
-                        const pos = editor.getPosition();
-                        if (pos?.lineNumber) {
-                            onCursorLineChange(pos.lineNumber);
+                    // 初期行を通知（存在する場合のみ）
+                    const pos = editor.getPosition();
+                    if (pos?.lineNumber) {
+                        cursorLineChangeRef.current?.(pos.lineNumber);
+                    }
+                    // カーソル移動で通知（常に登録し、最新のコールバックを参照）
+                    editor.onDidChangeCursorPosition((e) => {
+                        const ln = e.position?.lineNumber;
+                        if (typeof ln === 'number') {
+                            cursorLineChangeRef.current?.(ln);
                         }
-                        // カーソル移動で通知
-                        editor.onDidChangeCursorPosition((e) => {
-                            const ln = e.position?.lineNumber;
-                            if (typeof ln === 'number') {
-                                onCursorLineChange(ln);
-                            }
-                        });
-                    }
-                    if (onChangedLines) {
-                        editor.onDidChangeModelContent((e) => {
-                            const changed = new Set<number>();
-                            for (const ch of e.changes) {
-                                const start = ch.range.startLineNumber;
-                                const inserted = Math.max(0, ch.text.split(/\r?\n/).length - 1);
-                                const end = Math.max(ch.range.endLineNumber, ch.range.startLineNumber + inserted);
-                                for (let ln = start; ln <= end; ln += 1) changed.add(ln);
-                            }
-                            if (changed.size > 0) onChangedLines(Array.from(changed).sort((a, b) => a - b));
-                        });
-                    }
+                    });
+                    // コンテンツ変更で変更行を通知（常に登録し、最新のコールバックを参照）
+                    editor.onDidChangeModelContent((e) => {
+                        const changed = new Set<number>();
+                        for (const ch of e.changes) {
+                            const start = ch.range.startLineNumber;
+                            const inserted = Math.max(0, ch.text.split(/\r?\n/).length - 1);
+                            const end = Math.max(ch.range.endLineNumber, ch.range.startLineNumber + inserted);
+                            for (let ln = start; ln <= end; ln += 1) changed.add(ln);
+                        }
+                        if (changed.size > 0) {
+                            changedLinesRef.current?.(Array.from(changed).sort((a, b) => a - b));
+                        }
+                    });
                 }}
                 options={{
                     minimap: { enabled: false },

--- a/apps/studio/src/components/TopBar.tsx
+++ b/apps/studio/src/components/TopBar.tsx
@@ -164,6 +164,16 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                     <span className="hidden md:block text-xs ml-1">{!topbar.showPast ? 'Hide Past: ON' : 'Hide Past: OFF'}</span>
                 </Toolbar.Button>
 
+                <Toolbar.Button
+                    type="button"
+                    aria-label={!topbar.autoScroll ? 'Enable auto scroll' : 'Disable auto scroll'}
+                    title={!topbar.autoScroll ? 'Enable auto scroll' : 'Disable auto scroll'}
+                    onClick={() => onTopbarChange({ autoScroll: !topbar.autoScroll })}
+                    className={`inline-flex items-center justify-center px-2 h-full rounded-md border ${topbar.autoScroll ? 'text-white bg-gray-700 border-gray-700' : 'text-gray-700 bg-white hover:bg-gray-50 border-gray-300'}`}
+                >
+                    <span className="text-xs">Auto Scroll: {topbar.autoScroll ? 'ON' : 'OFF'}</span>
+                </Toolbar.Button>
+
                 <Toolbar.Separator className="w-px mr-auto" />
 
                 {/* Actions */}

--- a/apps/studio/src/components/TopBar.tsx
+++ b/apps/studio/src/components/TopBar.tsx
@@ -2,7 +2,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import * as Toolbar from '@radix-ui/react-toolbar';
-import { Check, ChevronDown, Clipboard, Columns, FileText, MoreHorizontal, PanelBottom, PanelLeft, PanelRight, PanelTop, Rows, Share2 } from 'lucide-react';
+import { Check, ChevronDown, Clipboard, Columns, Eye, EyeOff, FileText, MoreHorizontal, PanelBottom, PanelLeft, PanelRight, PanelTop, Rows, Share2 } from 'lucide-react';
 import * as React from 'react';
 import type { StayMode, TopbarState, ViewMode } from '../types/itinerary';
 
@@ -152,6 +152,17 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                         <PanelLeft size={14} className="hidden md:block" />
                     </ToggleGroup.Item>
                 </ToggleGroup.Root>
+
+                <Toolbar.Button
+                    type="button"
+                    aria-label={!topbar.showPast ? 'Show past days' : 'Hide past days'}
+                    title={!topbar.showPast ? 'Show past days' : 'Hide past days'}
+                    onClick={() => onTopbarChange({ showPast: !topbar.showPast })}
+                    className={`inline-flex items-center justify-center px-2 h-full rounded-md border ${!topbar.showPast ? 'text-white bg-gray-700 border-gray-700' : 'text-gray-700 bg-white hover:bg-gray-50 border-gray-300'}`}
+                >
+                    {!topbar.showPast ? <EyeOff size={14} /> : <Eye size={14} />}
+                    <span className="hidden md:block text-xs ml-1">{!topbar.showPast ? 'Hide Past: ON' : 'Hide Past: OFF'}</span>
+                </Toolbar.Button>
 
                 <Toolbar.Separator className="w-px mr-auto" />
 

--- a/apps/studio/src/components/itinerary/Heading.tsx
+++ b/apps/studio/src/components/itinerary/Heading.tsx
@@ -8,15 +8,25 @@ interface HeadingProps {
     prevStayName?: string;
 }
 
+const getDayOfWeekColorClass = (dayOfWeek: string) => {
+    switch (dayOfWeek) {
+        case 'Sat':
+            return 'text-blue-600';
+        case 'Sun':
+            return 'text-red-600';
+        default:
+            return 'text-gray-600';
+    }
+};
+
 export const Heading: React.FC<HeadingProps> = ({ date, timezone, prevStayName }) => {
     const dt = DateTime.fromISO(date, { zone: timezone || 'UTC' });
     const dayOfWeek = dt.isValid ? dt.setLocale('en').toFormat('ccc') : '';
-
     return (
         <h2 className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-y-2 text-xl font-semibold text-blue-700 border-b-2 border-blue-200 pb-3 mt-8 mb-6">
             <span className="flex items-center">
                 <span className="text-2xl whitespace-nowrap">{date}</span>
-                <span className="whitespace-nowrap ml-2 text-sm text-gray-600 bg-gray-200 px-2 py-1 rounded-md">{dayOfWeek}</span>
+                <span className={`whitespace-nowrap ml-2 text-sm px-2 py-0.5 bg-gray-200 ${getDayOfWeekColorClass(dayOfWeek)}`}>{dayOfWeek}</span>
                 {timezone && <span className="whitespace-nowrap ml-3 text-xs text-gray-500 font-normal">({timezone})</span>}
             </span>
             {prevStayName && (

--- a/apps/studio/src/components/itinerary/Item.tsx
+++ b/apps/studio/src/components/itinerary/Item.tsx
@@ -294,7 +294,8 @@ export const Item: React.FC<ItemProps> = ({ eventData, dateStr, timezone, curren
 
     const routeOrLocationDisplay = (() => {
         if (eventData.baseType === 'transportation' && eventData.departure && eventData.arrival) {
-            return <Route departure={eventData.departure} arrival={eventData.arrival} startTime={eventData.timeRange?.start} endTime={eventData.timeRange?.end} />;
+            const meta = eventData.metadata as Record<string, string>;
+            return <Route departure={eventData.departure} arrival={eventData.arrival} startTime={eventData.timeRange?.start} endTime={eventData.timeRange?.end} departureUrl={meta['departure__url']} arrivalUrl={meta['arrival__url']} />;
         }
         if ((eventData.baseType === 'stay' || eventData.baseType === 'activity') && eventData.location) {
             return <Location location={eventData.location} />;
@@ -322,7 +323,16 @@ export const Item: React.FC<ItemProps> = ({ eventData, dateStr, timezone, curren
             <div className={`flex-1 min-w-0 p-5 ${colors.cardBg} ${colors.cardBorder} border-l-4 ${colors.borderColor} -ml-4.5 pl-8`}>
                 <div className="flex items-center gap-x-3 flex-wrap">
                     {eventData.type === 'flight' && 'name' in eventData && eventData.name && <AirlineLogo flightCode={eventData.name} size={24} />}
-                    <span className={`font-bold ${colors.text} text-lg`}>{mainTitle}</span>
+                    {(() => {
+                        const url = (eventData.metadata as Record<string, string>)['name__url'];
+                        return url ? (
+                            <a href={url} target="_blank" rel="noopener noreferrer" className={`font-bold ${colors.text} text-lg hover:underline`}>
+                                {mainTitle}
+                            </a>
+                        ) : (
+                            <span className={`font-bold ${colors.text} text-lg`}>{mainTitle}</span>
+                        );
+                    })()}
                     {routeOrLocationDisplay && <div className="text-gray-700 text-sm font-medium">{routeOrLocationDisplay}</div>}
                 </div>
                 <Meta metadata={eventData.metadata} borderColor={colors.border} currency={currency} />

--- a/apps/studio/src/components/itinerary/Metadata.tsx
+++ b/apps/studio/src/components/itinerary/Metadata.tsx
@@ -42,7 +42,7 @@ export const Meta: React.FC<{
     borderColor: string;
     currency?: string;
 }> = ({ metadata, borderColor, currency }) => {
-    const entries = Object.entries(metadata);
+    const entries = Object.entries(metadata).filter(([key]) => !key.endsWith('__url'));
     const { data: ratesData } = useRatesUSD();
 
     const converted = useMemo(() => {
@@ -92,11 +92,19 @@ export const Meta: React.FC<{
                         </div>
                     );
                 }
+                const maybeUrl = metadata[`${key}__url`];
+                const content = maybeUrl ? (
+                    <a href={maybeUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline ml-1">
+                        {value}
+                    </a>
+                ) : (
+                    <span className="ml-1">{value}</span>
+                );
                 return (
                     <div key={key} className="text-gray-600 text-sm flex items-center">
                         <IconComponent size={14} className="mr-1" />
                         <span className="font-medium">{config.label}:</span>
-                        <span className="ml-1">{value}</span>
+                        {content}
                     </div>
                 );
             })}

--- a/apps/studio/src/components/itinerary/Route.tsx
+++ b/apps/studio/src/components/itinerary/Route.tsx
@@ -9,14 +9,28 @@ interface RouteProps {
     arrival: string;
     startTime?: TimeLike;
     endTime?: TimeLike;
+    departureUrl?: string;
+    arrivalUrl?: string;
 }
 
-export const Route: React.FC<RouteProps> = ({ departure, arrival, startTime, endTime }) => {
+export const Route: React.FC<RouteProps> = ({ departure, arrival, startTime, endTime, departureUrl, arrivalUrl }) => {
     return (
         <span className="flex items-center gap-2">
-            <Location location={departure} time={startTime} />
+            {departureUrl ? (
+                <a href={departureUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                    <Location location={departure} time={startTime} />
+                </a>
+            ) : (
+                <Location location={departure} time={startTime} />
+            )}
             <span className="text-gray-400">→</span>
-            <Location location={arrival} time={endTime} />
+            {arrivalUrl ? (
+                <a href={arrivalUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                    <Location location={arrival} time={endTime} />
+                </a>
+            ) : (
+                <Location location={arrival} time={endTime} />
+            )}
         </span>
     );
 };

--- a/apps/studio/src/hooks/useTopbarState.ts
+++ b/apps/studio/src/hooks/useTopbarState.ts
@@ -21,6 +21,7 @@ export function useTopbarState(): [TopbarState, (patch: Partial<TopbarState>) =>
         viewMode: 'split',
         stayMode: 'default',
         showPast: true,
+        autoScroll: true,
     }));
 
     useEffect(() => {
@@ -66,6 +67,9 @@ export function useTopbarState(): [TopbarState, (patch: Partial<TopbarState>) =>
             const past = searchParams.get('past');
             if (past) patch.showPast = past === '1';
 
+            const scroll = searchParams.get('scroll');
+            if (scroll) patch.autoScroll = scroll === '1';
+
             if (Object.keys(patch).length > 0) {
                 setState((prevState) => ({ ...prevState, ...patch }));
             }
@@ -89,7 +93,15 @@ export function useTopbarState(): [TopbarState, (patch: Partial<TopbarState>) =>
     useEffect(() => {
         try {
             const curr = new URLSearchParams(window.location.search);
-            if (curr.get('tz') === state.timezone && curr.get('cur') === state.currency && curr.get('view') === state.viewMode && curr.get('stay') === state.stayMode && curr.get('past') === (state.showPast ? '1' : '0')) return;
+            if (
+                curr.get('tz') === state.timezone &&
+                curr.get('cur') === state.currency &&
+                curr.get('view') === state.viewMode &&
+                curr.get('stay') === state.stayMode &&
+                curr.get('past') === (state.showPast ? '1' : '0') &&
+                curr.get('scroll') === (state.autoScroll ? '1' : '0')
+            )
+                return;
 
             const searchParams = new URLSearchParams(window.location.search);
             if (isValidIanaTimeZone(state.timezone)) {
@@ -99,12 +111,13 @@ export function useTopbarState(): [TopbarState, (patch: Partial<TopbarState>) =>
             searchParams.set('view', state.viewMode);
             searchParams.set('stay', state.stayMode);
             searchParams.set('past', state.showPast ? '1' : '0');
+            searchParams.set('scroll', state.autoScroll ? '1' : '0');
 
             const newSearch = `?${searchParams.toString()}`;
             const newUrl = `${window.location.pathname}${newSearch}${window.location.hash}`;
             history.replaceState(null, '', newUrl);
         } catch {}
-    }, [state.timezone, state.currency, state.viewMode, state.stayMode, state.showPast]);
+    }, [state.timezone, state.currency, state.viewMode, state.stayMode, state.showPast, state.autoScroll]);
 
     return [state, updateState];
 }

--- a/apps/studio/src/hooks/useTopbarState.ts
+++ b/apps/studio/src/hooks/useTopbarState.ts
@@ -20,6 +20,7 @@ export function useTopbarState(): [TopbarState, (patch: Partial<TopbarState>) =>
         currency: 'USD',
         viewMode: 'split',
         stayMode: 'default',
+        showPast: true,
     }));
 
     useEffect(() => {
@@ -62,6 +63,9 @@ export function useTopbarState(): [TopbarState, (patch: Partial<TopbarState>) =>
                 patch.stayMode = stay as StayMode;
             }
 
+            const past = searchParams.get('past');
+            if (past) patch.showPast = past === '1';
+
             if (Object.keys(patch).length > 0) {
                 setState((prevState) => ({ ...prevState, ...patch }));
             }
@@ -85,7 +89,7 @@ export function useTopbarState(): [TopbarState, (patch: Partial<TopbarState>) =>
     useEffect(() => {
         try {
             const curr = new URLSearchParams(window.location.search);
-            if (curr.get('tz') === state.timezone && curr.get('cur') === state.currency && curr.get('view') === state.viewMode && curr.get('stay') === state.stayMode) return;
+            if (curr.get('tz') === state.timezone && curr.get('cur') === state.currency && curr.get('view') === state.viewMode && curr.get('stay') === state.stayMode && curr.get('past') === (state.showPast ? '1' : '0')) return;
 
             const searchParams = new URLSearchParams(window.location.search);
             if (isValidIanaTimeZone(state.timezone)) {
@@ -94,12 +98,13 @@ export function useTopbarState(): [TopbarState, (patch: Partial<TopbarState>) =>
             searchParams.set('cur', state.currency);
             searchParams.set('view', state.viewMode);
             searchParams.set('stay', state.stayMode);
+            searchParams.set('past', state.showPast ? '1' : '0');
 
             const newSearch = `?${searchParams.toString()}`;
             const newUrl = `${window.location.pathname}${newSearch}${window.location.hash}`;
             history.replaceState(null, '', newUrl);
         } catch {}
-    }, [state.timezone, state.currency, state.viewMode, state.stayMode]);
+    }, [state.timezone, state.currency, state.viewMode, state.stayMode, state.showPast]);
 
     return [state, updateState];
 }

--- a/apps/studio/src/types/itinerary.ts
+++ b/apps/studio/src/types/itinerary.ts
@@ -7,6 +7,7 @@ export type TopbarState = {
     viewMode: ViewMode;
     stayMode: StayMode;
     showPast?: boolean;
+    autoScroll?: boolean;
 };
 
 export type QueryParams = {
@@ -15,6 +16,7 @@ export type QueryParams = {
     view?: ViewMode;
     stay?: StayMode;
     past?: '1' | '0';
+    scroll?: '1' | '0';
 };
 
 export type ItinerarySummary = {

--- a/apps/studio/src/types/itinerary.ts
+++ b/apps/studio/src/types/itinerary.ts
@@ -6,6 +6,7 @@ export type TopbarState = {
     currency: string;
     viewMode: ViewMode;
     stayMode: StayMode;
+    showPast?: boolean;
 };
 
 export type QueryParams = {
@@ -13,6 +14,7 @@ export type QueryParams = {
     cur?: string;
     view?: ViewMode;
     stay?: StayMode;
+    past?: '1' | '0';
 };
 
 export type ItinerarySummary = {

--- a/packages/core/src/remark/itinerary.ts
+++ b/packages/core/src/remark/itinerary.ts
@@ -86,6 +86,16 @@ export const remarkItinerary: Plugin<[Options?], Root> = (options?: Options) => 
                 continue;
             }
 
+            // Attach current date attributes to any non-heading node within the day's section
+            if (currentDateStr) {
+                const prevData = para.data || {};
+                const prevH = (prevData.hProperties as Record<string, unknown>) || {};
+                const hProps: Record<string, unknown> = { ...prevH };
+                if (!hProps['data-itin-date-str']) hProps['data-itin-date-str'] = currentDateStr;
+                if (currentDateTz && !hProps['data-itin-date-tz']) hProps['data-itin-date-tz'] = currentDateTz;
+                para.data = { ...prevData, hProperties: hProps } as MdNode['data'];
+            }
+
             if (para.type !== 'paragraph') continue;
 
             const paraChildren = (para as MdNode).children || [];

--- a/packages/core/src/remark/itinerary.ts
+++ b/packages/core/src/remark/itinerary.ts
@@ -98,8 +98,8 @@ export const remarkItinerary: Plugin<[Options?], Root> = (options?: Options) => 
 
             if (para.type !== 'paragraph') continue;
 
-            const paraChildren = (para as MdNode).children || [];
-            const firstLineText = paraChildren.length > 0 && paraChildren[0].type === 'text' ? String(paraChildren[0].value || '').trim() : mdastToString(para as MdNode).trim();
+            // Use full paragraph text to include link texts and inline nodes for parsing
+            const firstLineText = mdastToString(para as MdNode).trim();
 
             const parsed = parseTimeAndType(firstLineText, frontmatterTimezone);
             if (!parsed) continue;
@@ -159,9 +159,34 @@ export const remarkItinerary: Plugin<[Options?], Root> = (options?: Options) => 
                         const key = text.substring(0, colonIndex).trim().toLowerCase();
                         const value = text.substring(colonIndex + 1).trim();
                         mergedMeta[key] = value;
-                        const liChildren = (li as MdNode).children;
-                        const sublists = Array.isArray(liChildren) ? liChildren.filter((n) => n?.type === 'list') : [];
-                        liftedNodes.push(...sublists);
+
+                        // If the value part contains a markdown link, keep its URL alongside the value
+                        try {
+                            const liChildren = (li as MdNode).children;
+                            const firstPara = Array.isArray(liChildren) ? (liChildren.find((n) => n?.type === 'paragraph') as MdNode | undefined) : undefined;
+                            const findFirstLink = (node?: MdNode): string | undefined => {
+                                if (!node) return undefined;
+                                const kids = Array.isArray(node.children) ? node.children : [];
+                                for (const child of kids) {
+                                    if (!child) continue;
+                                    if ((child as { type?: string }).type === 'link') {
+                                        const url = (child as unknown as { url?: string }).url;
+                                        if (typeof url === 'string' && url.trim() !== '') return url;
+                                    }
+                                    const nested = findFirstLink(child as MdNode);
+                                    if (nested) return nested;
+                                }
+                                return undefined;
+                            };
+                            const url = findFirstLink(firstPara);
+                            if (url) {
+                                mergedMeta[`${key}__url`] = url;
+                            }
+                            const sublists = Array.isArray(liChildren) ? liChildren.filter((n) => n?.type === 'list') : [];
+                            liftedNodes.push(...sublists);
+                        } catch {
+                            // no-op on link extraction failure
+                        }
                         continue;
                     }
                     remainingItems.push(li);
@@ -198,10 +223,42 @@ export const remarkItinerary: Plugin<[Options?], Root> = (options?: Options) => 
                 }
             }
 
+            // Collect link texts in this paragraph for later association (e.g., flight code, airport)
+            const collectLinks = (node?: MdNode, acc?: Record<string, string>): Record<string, string> => {
+                const out = acc || {};
+                if (!node) return out;
+                const kids = Array.isArray(node.children) ? node.children : [];
+                for (const child of kids) {
+                    if (!child) continue;
+                    if ((child as { type?: string }).type === 'link') {
+                        const url = (child as unknown as { url?: string }).url;
+                        const label = mdastToString(child as MdNode).trim();
+                        if (label && typeof url === 'string' && url.trim() !== '' && !out[label]) {
+                            out[label] = url;
+                        }
+                    }
+                    collectLinks(child as MdNode, out);
+                }
+                return out;
+            };
+            const linkMap = collectLinks(para as MdNode, {});
+
             const parseTimezone = currentDateTz && isValidIanaTimeZone(currentDateTz) ? currentDateTz : isValidIanaTimeZone(frontmatterTimezone) ? frontmatterTimezone : options?.timezone;
             const eventData = parseEvent(rebuilt, previousEvent || undefined, parseTimezone, currentDateStr);
             if (eventData) {
-                const mergedEvent = { ...eventData, metadata: { ...eventData.metadata, ...itinMeta } } as typeof eventData;
+                // Attach URL metadata based on label matching
+                const urlEnhancedMeta: Record<string, string> = { ...itinMeta };
+                if ('name' in eventData && eventData.name && linkMap[eventData.name]) {
+                    urlEnhancedMeta['name__url'] = linkMap[eventData.name];
+                }
+                if ('departure' in eventData && eventData.departure && linkMap[eventData.departure]) {
+                    urlEnhancedMeta['departure__url'] = linkMap[eventData.departure];
+                }
+                if ('arrival' in eventData && eventData.arrival && linkMap[eventData.arrival]) {
+                    urlEnhancedMeta['arrival__url'] = linkMap[eventData.arrival];
+                }
+
+                const mergedEvent = { ...eventData, metadata: { ...eventData.metadata, ...urlEnhancedMeta } } as typeof eventData;
                 if (options?.stayMode === 'header' && mergedEvent.type === 'stay') {
                     if (mergedEvent.stayName) {
                         lastStayName = mergedEvent.stayName;
@@ -222,7 +279,8 @@ export const remarkItinerary: Plugin<[Options?], Root> = (options?: Options) => 
 
             para.data = { ...prevData, itinMeta, hProperties: hProps } as MdNode['data'];
 
-            para.children = [{ type: 'text', value: rebuilt }];
+            // Preserve original paragraph children to keep Markdown structures (e.g., links)
+            // Do not overwrite para.children with a rebuilt plain text
         }
         return tree;
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - エディタのカーソル行とプレビューを自動同期（自動スクロール）—トップバーでON/OFF切替可。
  - 過去イベントの表示/非表示トグルを追加。非表示件数インジケーターを見出しに表示。
  - イベントの名称・出発地・到着地が対応するURL指定時にクリック可能なリンクに。
  - 設定はURLパラメータ（past, scroll）に反映・復元。

- スタイル
  - 曜日バッジを色分け（例: 土曜=青、日曜=赤）し視認性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->