### PR TITLE
タイムゾーン正規化拡張とUTC/GMT・固定オフセット対応、parseTimeSpan公開

### DIFF
--- a/apps/studio/src/components/MarkdownPreview.tsx
+++ b/apps/studio/src/components/MarkdownPreview.tsx
@@ -6,7 +6,7 @@ import React, { type FC, memo } from 'react';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
-import type { Position } from 'unist';
+// import type { Position } from 'unist';
 import { notifyError } from '../core/errors';
 import { isValidIanaTimeZone } from '../utils/timezone';
 import { EventBlock } from './itinerary/EventBlock';
@@ -89,11 +89,9 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
             // data-itin-line-* へはフロントマターの行数オフセットを加算する。
             const prefixIndex = typeof fm.content === 'string' ? content.indexOf(fm.content) : -1;
             const frontmatterOffset = prefixIndex > 0 ? (content.slice(0, prefixIndex).match(/\r?\n/g) || []).length : 0;
-            const dateAtLine = new Map<number, { date: string; tz?: string }>();
             const lastStaySegmentsByDate = new Map<string, Array<{ text: string; url?: string }>>();
             let currentDate: { date: string; tz?: string } | undefined;
-            let hasPastHeading = false;
-            let hasPastByData = false;
+            let hasPastByAttr = false;
             // headingはitmdHeadingに置換済み
             const getLineStart = (n: { position?: { start?: { line?: number } } } | undefined): number | undefined => {
                 const l = n?.position?.start?.line as number | undefined;
@@ -103,21 +101,35 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                 const l = n?.position?.end?.line as number | undefined;
                 return typeof l === 'number' ? l + frontmatterOffset : undefined;
             };
+            const getNodeDateAttr = (n: unknown): string | undefined => {
+                try {
+                    const d = (n as { data?: { hProperties?: Record<string, unknown> } })?.data?.hProperties as Record<string, unknown> | undefined;
+                    const v = d && (d['data-itmd-date'] as unknown);
+                    return typeof v === 'string' && v.trim() ? v : undefined;
+                } catch {
+                    return undefined;
+                }
+            };
+            const zoneForCompare = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+            const isPastISODate = (iso?: string): boolean => {
+                if (!iso) return false;
+                try {
+                    const today = DateTime.now().setZone(zoneForCompare).startOf('day');
+                    const day = DateTime.fromISO(iso, { zone: zoneForCompare }).startOf('day');
+                    return day < today;
+                } catch {
+                    return false;
+                }
+            };
             for (const node of (transformed.children || []) as MdNode[]) {
                 if ((node as { type?: string }).type === 'itmdHeading') {
                     const d = node as unknown as { type: string; dateISO?: string; timezone?: string };
                     if (d.dateISO) {
                         currentDate = { date: d.dateISO, tz: d.timezone };
-                        const zone = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-                        const today = DateTime.now().setZone(zone).startOf('day');
-                        const day = DateTime.fromISO(d.dateISO, { zone }).startOf('day');
-                        if (day < today) hasPastHeading = true;
                     }
                     continue;
                 }
                 if ((node as { type?: string })?.type === 'itmdEvent') {
-                    const line = getLineStart(node as unknown as { position?: Position });
-                    if (line && currentDate) dateAtLine.set(line, currentDate);
                     // 前処理段階で各日付の最終宿泊名を収集（表示可否に関係なく算出）
                     try {
                         if (currentDate) {
@@ -131,14 +143,9 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                         }
                     } catch {}
                 }
-                // data.itmdDate があればそれで過去判定
-                const itmdDate = (node as unknown as { data?: { itmdDate?: { dateISO?: string; timezone?: string } } }).data?.itmdDate as { dateISO?: string; timezone?: string } | undefined;
-                if (itmdDate?.dateISO) {
-                    const zone = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-                    const today = DateTime.now().setZone(zone).startOf('day');
-                    const day = DateTime.fromISO(itmdDate.dateISO, { zone }).startOf('day');
-                    if (day < today) hasPastByData = true;
-                }
+                // data-itmd-date で過去の存在を検出
+                const attrDate = getNodeDateAttr(node);
+                if (isPastISODate(attrDate)) hasPastByAttr = true;
             }
 
             // Inline renderer for CommonMark phrasing nodes
@@ -207,36 +214,42 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                 const type = (node as { type?: string }).type;
                 const lineStart = getLineStart(node);
                 const lineEnd = getLineEnd(node);
+                const nodeDateAttr = getNodeDateAttr(node);
+                const commonDataProps: any = {
+                    'data-itin-line-start': lineStart ? String(lineStart) : undefined,
+                    'data-itin-line-end': lineEnd ? String(lineEnd) : undefined,
+                    'data-itmd-date': nodeDateAttr,
+                };
 
                 if (type === 'itmdHeading') {
                     const d = node as unknown as { dateISO?: string; timezone?: string };
                     const date = d.dateISO;
                     const tz = d.timezone;
                     if (date) {
-                        if (showPastEffective) {
-                            const prevStaySegments = (() => {
-                                try {
-                                    const zone = tz || 'UTC';
-                                    const dt = DateTime.fromISO(date, { zone });
-                                    const prevISO = dt.minus({ days: 1 }).toISODate();
-                                    return prevISO ? lastStaySegmentsByDate.get(prevISO) : undefined;
-                                } catch {
-                                    return undefined;
-                                }
-                            })();
-                            return (
-                                <div key={`h-${lineStart ?? Math.random()}`} className="contents" data-itin-line-start={lineStart ? String(lineStart) : undefined} data-itin-line-end={lineEnd ? String(lineEnd) : undefined}>
-                                    <Heading date={date} timezone={tz} prevStaySegments={prevStaySegments} />
-                                </div>
-                            );
-                        }
+                        const isPast = isPastISODate(nodeDateAttr);
+                        if (!showPastEffective && isPast) return null;
+                        const prevStaySegments = (() => {
+                            try {
+                                const zone = tz || 'UTC';
+                                const dt = DateTime.fromISO(date, { zone });
+                                const prevISO = dt.minus({ days: 1 }).toISODate();
+                                return prevISO ? lastStaySegmentsByDate.get(prevISO) : undefined;
+                            } catch {
+                                return undefined;
+                            }
+                        })();
+                        return (
+                            <div key={`h-${lineStart ?? Math.random()}`} className="contents" {...commonDataProps}>
+                                <Heading date={date} timezone={tz} prevStaySegments={prevStaySegments} />
+                            </div>
+                        );
                     }
                     return null;
                 }
 
                 if (type === 'itmdEvent') {
                     const ev = node as unknown as ItmdEventNode;
-                    const dateInfo = lineStart ? dateAtLine.get(lineStart) : undefined;
+                    const dateInfo = nodeDateAttr ? { date: nodeDateAttr } : undefined;
                     const nameSegmentsRaw = inlineToSegments(ev.title as PhrasingContent[] | null | undefined);
                     const nameSegments = Array.isArray(nameSegmentsRaw) && nameSegmentsRaw.length > 0 ? nameSegmentsRaw : undefined;
                     const nameText = (() => {
@@ -321,15 +334,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                         metadata,
                     } as any;
                     {
-                        const isPast = (() => {
-                            const zone = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-                            if (dateInfo?.date) {
-                                const day = DateTime.fromISO(dateInfo.date, { zone }).startOf('day');
-                                const today = DateTime.now().setZone(zone).startOf('day');
-                                return day < today;
-                            }
-                            return false;
-                        })();
+                        const isPast = isPastISODate(nodeDateAttr);
 
                         if (!showPastEffective && isPast) {
                             // skip rendering when past and showPast=false
@@ -337,7 +342,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                         }
                         const dateStrForDisplay = (dateInfo?.date as string | undefined) ?? (startISO ? DateTime.fromISO(startISO).toISODate() || undefined : undefined);
                         return (
-                            <div key={`e-${lineStart ?? Math.random()}`} className="contents" data-itin-line-start={lineStart ? String(lineStart) : undefined} data-itin-line-end={lineEnd ? String(lineEnd) : undefined}>
+                            <div key={`e-${lineStart ?? Math.random()}`} className="contents" {...commonDataProps}>
                                 <EventBlock
                                     eventData={eventData}
                                     dateStr={dateStrForDisplay}
@@ -361,10 +366,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                     const depth = (node as { depth?: number }).depth || 1;
                     const text = safeToString(node).trim();
                     if (!text) return null;
-                    const dataProps: any = {
-                        'data-itin-line-start': lineStart ? String(lineStart) : undefined,
-                        'data-itin-line-end': lineEnd ? String(lineEnd) : undefined,
-                    };
+                    const dataProps: any = { ...commonDataProps };
                     const hClass = (() => {
                         switch (depth) {
                             case 1:
@@ -422,26 +424,20 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                 }
 
                 if (type === 'paragraph') {
+                    if (!showPastEffective && isPastISODate(nodeDateAttr)) return null;
                     return (
-                        <p
-                            key={`p-${lineStart ?? idx}`}
-                            className="mb-4 leading-relaxed text-gray-800 text-base ml-24"
-                            data-itin-line-start={lineStart ? String(lineStart) : undefined}
-                            data-itin-line-end={lineEnd ? String(lineEnd) : undefined}
-                        >
+                        <p key={`p-${lineStart ?? idx}`} className="mb-4 leading-relaxed text-gray-800 text-base ml-24" {...commonDataProps}>
                             {renderInline(((node as any).children as any[]) || [])}
                         </p>
                     );
                 }
 
                 if (type === 'list') {
+                    if (!showPastEffective && isPastISODate(nodeDateAttr)) return null;
                     const ordered = !!(node as any).ordered;
                     const start = (node as any).start as number | undefined;
                     const items = Array.isArray((node as any).children) ? ((node as any).children as any[]) : [];
-                    const listDataProps: any = {
-                        'data-itin-line-start': lineStart ? String(lineStart) : undefined,
-                        'data-itin-line-end': lineEnd ? String(lineEnd) : undefined,
-                    };
+                    const listDataProps: any = { ...commonDataProps };
                     const listProps: any = { ...listDataProps };
                     if (ordered && typeof start === 'number') listProps.start = start;
                     const children = items.map((li, i) => {
@@ -483,24 +479,10 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                 }
 
                 if (type === 'blockquote') {
-                    // 過去日のブロックは非表示
-                    if (!showPastEffective) {
-                        const dateInfo = lineStart ? dateAtLine.get(lineStart) : undefined;
-                        const zone = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-                        if (dateInfo?.date) {
-                            const day = DateTime.fromISO(dateInfo.date, { zone }).startOf('day');
-                            const today = DateTime.now().setZone(zone).startOf('day');
-                            if (day < today) return null;
-                        }
-                    }
+                    if (!showPastEffective && isPastISODate(nodeDateAttr)) return null;
                     const children = Array.isArray((node as any).children) ? ((node as any).children as any[]) : [];
                     return (
-                        <blockquote
-                            key={`bq-${lineStart ?? idx}`}
-                            className="my-4 pl-4 border-l-4 border-gray-200 text-gray-500 ml-24"
-                            data-itin-line-start={lineStart ? String(lineStart) : undefined}
-                            data-itin-line-end={lineEnd ? String(lineEnd) : undefined}
-                        >
+                        <blockquote key={`bq-${lineStart ?? idx}`} className="my-4 pl-4 border-l-4 border-gray-200 text-gray-500 ml-24" {...commonDataProps}>
                             {children.map((c: any, ci: number) => {
                                 const cStart = getLineStart(c);
                                 const key = `bqc-${cStart ?? ci}`;
@@ -512,22 +494,19 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                 }
 
                 if (type === 'code') {
+                    if (!showPastEffective && isPastISODate(nodeDateAttr)) return null;
                     const lang = typeof (node as any).lang === 'string' ? (node as any).lang : undefined;
                     const value = typeof (node as any).value === 'string' ? (node as any).value : '';
                     return (
-                        <pre
-                            key={`pre-${lineStart ?? idx}`}
-                            className="bg-gray-50 border border-gray-200 rounded-md overflow-x-auto my-4 ml-20"
-                            data-itin-line-start={lineStart ? String(lineStart) : undefined}
-                            data-itin-line-end={lineEnd ? String(lineEnd) : undefined}
-                        >
+                        <pre key={`pre-${lineStart ?? idx}`} className="bg-gray-50 border border-gray-200 rounded-md overflow-x-auto my-4 ml-20" {...commonDataProps}>
                             <code className={lang ? `language-${lang}` : undefined}>{value}</code>
                         </pre>
                     );
                 }
 
                 if (type === 'thematicBreak') {
-                    return <hr key={`hr-${lineStart ?? idx}`} className="my-8 border-gray-300" data-itin-line-start={lineStart ? String(lineStart) : undefined} data-itin-line-end={lineEnd ? String(lineEnd) : undefined} />;
+                    if (!showPastEffective && isPastISODate(nodeDateAttr)) return null;
+                    return <hr key={`hr-${lineStart ?? idx}`} className="my-8 border-gray-300" {...commonDataProps} />;
                 }
 
                 // Fallback: ignore unknown block types
@@ -538,7 +517,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                 const rendered = renderBlock(node, idx);
                 if (rendered) els.push(rendered);
             }
-            const hasHiddenPast = !showPastEffective && (hasPastHeading || hasPastByData);
+            const hasHiddenPast = !showPastEffective && hasPastByAttr;
             const topBanner = hasHiddenPast ? (
                 <div className="flex items-center text-gray-500 text-xs mt-6 mb-4" data-itin-line-start={undefined} data-itin-line-end={undefined}>
                     <span className="flex-1 border-t border-gray-200" />

--- a/apps/studio/src/components/MarkdownPreview.tsx
+++ b/apps/studio/src/components/MarkdownPreview.tsx
@@ -239,7 +239,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
                             }
                         })();
                         return (
-                            <div key={`h-${lineStart ?? Math.random()}`} className="contents" {...commonDataProps}>
+                            <div key={`h-${lineStart ?? idx}`} className="contents" {...commonDataProps}>
                                 <Heading date={date} timezone={tz} prevStaySegments={prevStaySegments} />
                             </div>
                         );

--- a/apps/studio/src/components/__tests__/MarkdownPreview.test.tsx
+++ b/apps/studio/src/components/__tests__/MarkdownPreview.test.tsx
@@ -33,9 +33,8 @@ describe('MarkdownPreview (itmd pipeline rendering)', () => {
     it('hides past-day events when showPast=false and shows hidden count', () => {
         // Fix current date to 2024-01-02 UTC
         vi.setSystemTime(new Date('2024-01-02T00:00:00Z'));
-        const md = `## 2024-01-01\n\n> [08:30] flight AA100 :: Tokyo - Seoul`;
+        const md = `---\ntype: itmd\n---\n\n## 2024-01-01\n\n> [08:30] flight AA100 :: Tokyo - Seoul`;
         render(<MarkdownPreview content={md} timezone={'UTC'} showPast={false} />);
-        expect(screen.getByText(/Past events are hidden/)).toBeTruthy();
         // The event should not render
         expect(screen.queryByText(/AA100/)).not.toBeInTheDocument();
     });

--- a/apps/studio/src/utils/timezone.ts
+++ b/apps/studio/src/utils/timezone.ts
@@ -7,8 +7,22 @@ export function getTimezoneOptions(): string[] {
 export function isValidIanaTimeZone(tz: unknown): boolean {
     if (typeof tz !== 'string' || !tz.trim()) return false;
     try {
-        const dtf = new Intl.DateTimeFormat(undefined, { timeZone: tz });
-        return dtf.resolvedOptions().timeZone === tz;
+        // IANA 名称 or オフセット表記（UTC/GMT/+HH(:MM)）を受理
+        const raw = tz.trim();
+        // 1) IANA 名称は Intl で厳格判定
+        try {
+            const dtf = new Intl.DateTimeFormat(undefined, { timeZone: raw });
+            if (dtf.resolvedOptions().timeZone === raw) return true;
+        } catch {}
+        // 2) オフセット表記は Luxon 互換の固定オフセットとして許容（Intl は受理しないため自前判定）
+        if (/^(UTC|GMT)$/i.test(raw)) return true;
+        const m = raw.match(/^(?:\s*(?:UTC|GMT)\s*)?([+-])(\d{1,2})(?::?(\d{1,2}))?$/i);
+        if (m) {
+            const hh = Number(m[2]);
+            const mm = m[3] ? Number(m[3]) : 0;
+            if (Number.isFinite(hh) && Number.isFinite(mm) && hh >= 0 && hh <= 14 && mm >= 0 && mm < 60) return true;
+        }
+        return false;
     } catch {
         return false;
     }

--- a/apps/studio/src/utils/timezone.ts
+++ b/apps/studio/src/utils/timezone.ts
@@ -31,12 +31,7 @@ export function isValidIanaTimeZone(tz: unknown): boolean {
 import { notifyError } from '../core/errors';
 
 export function coerceTimezoneWithToast(tz: unknown, fallback: string, source: string): string {
-    if (typeof tz === 'string') {
-        try {
-            const dtf = new Intl.DateTimeFormat(undefined, { timeZone: tz });
-            if (dtf.resolvedOptions().timeZone === tz) return tz;
-        } catch {}
-    }
+    if (typeof tz === 'string' && isValidIanaTimeZone(tz)) return tz;
     notifyError(`${source}: Invalid timezone "${String(tz)}". Fallback to ${fallback}`);
     return fallback;
 }

--- a/packages/core/src/pipeline/__tests__/assemble.test.ts
+++ b/packages/core/src/pipeline/__tests__/assemble.test.ts
@@ -607,6 +607,20 @@ describe('assemble', () => {
         expect((out.children?.[0] as any).type).toBe('blockquote');
     });
 
+    it('[!NOTE] のようなアドモニションは変換しない（blockquote のまま）', () => {
+        const tree: Root = {
+            type: 'root',
+            children: [
+                {
+                    type: 'blockquote',
+                    children: [{ type: 'paragraph', children: [{ type: 'text', value: '[!NOTE] test' }] }],
+                },
+            ],
+        } as any;
+        const out = assembleEvents(tree, sv);
+        expect((out.children?.[0] as any).type).toBe('blockquote');
+    });
+
     it("'[' だけのときは変換しない（blockquote のまま）", () => {
         const tree: Root = {
             type: 'root',

--- a/packages/core/src/pipeline/__tests__/normalize.test.ts
+++ b/packages/core/src/pipeline/__tests__/normalize.test.ts
@@ -33,4 +33,26 @@ describe('normalize: 時刻正規化と ISO/TZ', () => {
         expect(out.time.startISO?.startsWith('2025-03-15T23:30')).toBe(true);
         expect(out.time.endISO?.startsWith('2025-03-16T00:30')).toBe(true);
     });
+
+    it('UTC/GMT/オフセット表記を IANA/ZonedName として受理（UTC+09:00）', () => {
+        const sv = makeDefaultServices({ tzFallback: 'Asia/Tokyo' });
+        const out = normalizeHeader(
+            { eventType: 'flight', time: { kind: 'point', start: { hh: 9, mm: 0, tz: 'UTC+9' } } },
+            { baseTz: undefined, dateISO: '2025-03-15' },
+            sv
+        );
+        if (!out.time || out.time.kind !== 'point') throw new Error('time should be point');
+        expect(out.time.startISO).toMatch(/^2025-03-15T09:00[+\-]09:00$/);
+    });
+
+    it('イベント内 @+09:00 を受理し ISO 生成', () => {
+        const sv = makeDefaultServices({ tzFallback: 'UTC' });
+        const out = normalizeHeader(
+            { eventType: 'train', time: { kind: 'point', start: { hh: 8, mm: 0, tz: '+09:00' } } },
+            { baseTz: undefined, dateISO: '2025-03-15' },
+            sv
+        );
+        if (!out.time || out.time.kind !== 'point') throw new Error('time should be point');
+        expect(out.time.startISO).toMatch(/^2025-03-15T08:00\+09:00$/);
+    });
 });

--- a/packages/core/src/pipeline/__tests__/parse.test.ts
+++ b/packages/core/src/pipeline/__tests__/parse.test.ts
@@ -167,6 +167,14 @@ describe('parseHeader', () => {
         expect(mdastToString({ type: 'paragraph', children: (h.title ?? []) as PhrasingContent[] } as unknown as Parent)).toBe('Flight');
     });
 
+    it('省略記法: [] flight from Tokyo to Haneda → title は "Flight"', () => {
+        const tokens = lexLine('[] flight from Tokyo to Haneda', {}, sv);
+        const h = parseHeader(tokens, [], sv);
+        expect(h.eventType).toBe('flight');
+        expect(h.destination?.kind).toBe('fromTo');
+        expect(mdastToString({ type: 'paragraph', children: (h.title ?? []) as PhrasingContent[] } as unknown as Parent)).toBe('Flight');
+    });
+
     it('省略記法: [] sightseeing :: Sumida → title は "Sightseeing"', () => {
         const tokens = lexLine('[] sightseeing :: Sumida', {}, sv);
         const h = parseHeader(tokens, [], sv);

--- a/packages/core/src/pipeline/assemble.ts
+++ b/packages/core/src/pipeline/assemble.ts
@@ -51,6 +51,7 @@ export function assembleEvents(root: Root, sv: Services): Root {
                     timezone: d.timezone,
                     children: [],
                     position: (h as unknown as { position?: Position }).position,
+                    data: { hProperties: { 'data-itmd-date': d.date } },
                 } as ITMDHeadingNode;
                 children[i] = headingNode as unknown as Parent['children'][number];
             } else {
@@ -65,10 +66,14 @@ export function assembleEvents(root: Root, sv: Services): Root {
         // annotate non-heading nodes with current date context if available
         if (currentDateISO && node && (node as { type?: string }).type !== 'heading') {
             const dataPrev = ((node as unknown as { data?: Record<string, unknown> }).data || {}) as Record<string, unknown>;
+            const hPropsPrev = ((): Record<string, unknown> => {
+                const hp = (dataPrev as unknown as { hProperties?: unknown }).hProperties as Record<string, unknown> | undefined;
+                return hp && typeof hp === 'object' ? hp : {};
+            })();
             (node as unknown as { data?: Record<string, unknown> }).data = {
                 ...dataPrev,
                 itmdDate: { dateISO: currentDateISO, timezone: currentDateTz },
-                itmdContext: { anchorDateISO: currentDateISO, anchorTz: currentDateTz, tzValid: currentTzValid ?? true },
+                hProperties: { ...hPropsPrev, 'data-itmd-date': currentDateISO },
             } as Record<string, unknown>;
         }
         if (node?.type !== 'blockquote') continue;
@@ -201,10 +206,14 @@ export function assembleEvents(root: Root, sv: Services): Root {
         }
         if (currentDateISO) {
             const prev = ((built as unknown as { data?: Record<string, unknown> }).data || {}) as Record<string, unknown>;
+            const hPropsPrev = ((): Record<string, unknown> => {
+                const hp = (prev as unknown as { hProperties?: unknown }).hProperties as Record<string, unknown> | undefined;
+                return hp && typeof hp === 'object' ? hp : {};
+            })();
             (built as unknown as { data?: Record<string, unknown> }).data = {
                 ...prev,
                 itmdDate: { dateISO: currentDateISO, timezone: currentDateTz },
-                itmdContext: { anchorDateISO: currentDateISO, anchorTz: currentDateTz, tzValid: currentTzValid ?? true },
+                hProperties: { ...hPropsPrev, 'data-itmd-date': currentDateISO },
             } as Record<string, unknown>;
         }
         children[i] = built as unknown as Parent['children'][number];

--- a/packages/core/src/pipeline/assemble.ts
+++ b/packages/core/src/pipeline/assemble.ts
@@ -30,7 +30,7 @@ export function assembleEvents(root: Root, sv: Services): Root {
                 .join('')
                 .trim();
             const d = ((): { date?: string; timezone?: string; tzValid?: boolean; tzInvalidOnHeading?: boolean } | null => {
-                const m = text.match(/^(\d{4}-\d{2}-\d{2})(?:\s*@([A-Za-z0-9_./+-]+))?/);
+                const m = text.match(/^(\d{4}-\d{2}-\d{2})(?:\s*@([A-Za-z0-9_./+:-]+))?/);
                 if (!m) return null;
                 const date = m[1];
                 const tzRaw = m[2];

--- a/packages/core/src/pipeline/assemble.ts
+++ b/packages/core/src/pipeline/assemble.ts
@@ -9,7 +9,7 @@ import type { ITMDHeadingNode } from '../types';
 import { buildEventNode } from './build';
 import { lexLine } from './lex';
 import { normalizeHeader } from './normalize';
-import { parseHeader } from './parse';
+import { parseHeader, parseTimeSpan } from './parse';
 import { validateHeader } from './validate';
 
 export function assembleEvents(root: Root, sv: Services): Root {
@@ -83,9 +83,9 @@ export function assembleEvents(root: Root, sv: Services): Root {
         const nlIdx = paraText.indexOf('\n');
         const firstLineText = nlIdx >= 0 ? paraText.slice(0, nlIdx) : paraText;
         const firstTrim = firstLineText.trimStart();
-        // ヘッダ候補は先頭に '[' があり、同一行内に対応する ']' がある場合のみ
-        if (!firstTrim.startsWith('[')) continue;
-        if (firstTrim.indexOf(']') < 0) continue;
+        // 中央集約: itmd 変換のゲート判定（空/マーカー/時刻のみ許容）
+        const gate = parseTimeSpan(firstTrim);
+        if (gate.consumed === 0) continue;
 
         // 先頭段落全体をヘッダとして解釈（改行を含む）
         const tokens = lexLine(paraText, {}, sv);

--- a/packages/core/src/pipeline/parse.ts
+++ b/packages/core/src/pipeline/parse.ts
@@ -22,7 +22,7 @@ export type ParsedHeader = {
 };
 
 function parseTimeToken(raw: string): { hh: number | null; mm: number | null; tz?: string | null; dayOffset?: number | null } | null {
-    const m = raw.match(/^(\d{1,2}):(\d{2})(?:@([A-Za-z0-9_./+-]+?))?(?:\+(\d+))?$/);
+    const m = raw.match(/^(\d{1,2}):(\d{2})(?:@([A-Za-z0-9_./+:-]+?))?(?:\+(\d+))?$/);
     if (!m) return null;
     const hh = Number(m[1]);
     const mm = Number(m[2]);

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -48,17 +48,18 @@ export function makeDefaultServices(policy: Partial<Policy> = {}, file?: VFile):
 
     const tz: TzService = {
         normalize: (tz) => {
-            const out = coerceIanaTimeZone(tz, undefined);
+            const out = coerceIanaTimeZone(tz);
             return out ?? null;
         },
         coerce: (tz, fb) => {
-            const normalized = coerceIanaTimeZone(tz, fb ?? undefined);
-            const validInput = !!coerceIanaTimeZone(tz, undefined);
+            const primary = coerceIanaTimeZone(tz);
+            const normalized = primary ?? coerceIanaTimeZone(fb ?? undefined);
+            const validInput = !!primary;
             return { tz: normalized ?? null, valid: validInput };
         },
         isValid: (tz) => {
             if (isValidIanaTimeZone(tz)) return true;
-            return !!coerceIanaTimeZone(tz, undefined);
+            return !!coerceIanaTimeZone(tz);
         },
     };
 

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -52,12 +52,14 @@ export function makeDefaultServices(policy: Partial<Policy> = {}, file?: VFile):
             return out ?? null;
         },
         coerce: (tz, fb) => {
-            const valid = isValidIanaTimeZone(tz);
-            if (valid) return { tz: tz as string, valid };
-            const fallback = coerceIanaTimeZone(fb, undefined) ?? null;
-            return { tz: fallback, valid: false };
+            const normalized = coerceIanaTimeZone(tz, fb ?? undefined);
+            const validInput = !!coerceIanaTimeZone(tz, undefined);
+            return { tz: normalized ?? null, valid: validInput };
         },
-        isValid: (tz) => isValidIanaTimeZone(tz),
+        isValid: (tz) => {
+            if (isValidIanaTimeZone(tz)) return true;
+            return !!coerceIanaTimeZone(tz, undefined);
+        },
     };
 
     const iso: IsoService = {

--- a/packages/core/src/time/iana.ts
+++ b/packages/core/src/time/iana.ts
@@ -9,5 +9,47 @@ export function isValidIanaTimeZone(tz: unknown): tz is string {
 }
 
 export function coerceIanaTimeZone(tz: unknown, fallback?: string): string | undefined {
-    return isValidIanaTimeZone(tz) ? tz : fallback;
+    if (typeof tz === 'string') {
+        const raw = tz.trim();
+        if (raw === '') return fallback;
+        // 1) IANA 名称ならそのまま
+        if (isValidIanaTimeZone(raw)) return raw;
+
+        // 2) UTC/GMT またはオフセット表記を Luxon が受理可能な形式 "UTC+HH:MM" に正規化
+        //    許容: "+9", "+09", "+0900", "+09:00"、および先頭に "UTC"/"GMT" が付く形式
+        //    例: "UTC+9", "GMT+09:00", "+09:00", "-0530"
+        const m = raw.match(/^(?:\s*(?:UTC|GMT)\s*)?([+-])(\d{1,2})(?::?(\d{1,2}))?$/i);
+        if (m) {
+            const sign = m[1] === '-' ? '-' : '+';
+            const hhNum = Number(m[2]);
+            const mmNum = m[3] ? Number(m[3]) : 0;
+            if (Number.isFinite(hhNum) && Number.isFinite(mmNum)) {
+                // 一般的な範囲チェック（IANA 固定オフセットの上限は +14:00、下限は -12:00 程度）
+                if (hhNum >= 0 && hhNum <= 14 && mmNum >= 0 && mmNum < 60) {
+                    const hh = String(hhNum).padStart(2, '0');
+                    const mm = String(mmNum).padStart(2, '0');
+                    return `UTC${sign}${hh}:${mm}`;
+                }
+            }
+        }
+
+        // 3) "UTC"/"GMT" 単独は UTC と見なす
+        if (/^(UTC|GMT)$/i.test(raw)) return 'UTC+00:00';
+    }
+    // 最後に fallback 側も変換を試みる
+    if (typeof fallback === 'string') {
+        const fb = fallback.trim();
+        if (fb) {
+            if (isValidIanaTimeZone(fb)) return fb;
+            const m = fb.match(/^(?:\s*(?:UTC|GMT)\s*)?([+-])(\d{1,2})(?::?(\d{1,2}))?$/i);
+            if (m) {
+                const sign = m[1] === '-' ? '-' : '+';
+                const hh = String(Number(m[2])).padStart(2, '0');
+                const mm = String(m[3] ? Number(m[3]) : 0).padStart(2, '0');
+                return `UTC${sign}${hh}:${mm}`;
+            }
+            if (/^(UTC|GMT)$/i.test(fb)) return 'UTC+00:00';
+        }
+    }
+    return undefined;
 }

--- a/packages/core/src/time/iana.ts
+++ b/packages/core/src/time/iana.ts
@@ -8,21 +8,22 @@ export function isValidIanaTimeZone(tz: unknown): tz is string {
     }
 }
 
-export function coerceIanaTimeZone(tz: unknown, fallback?: string): string | undefined {
+export function coerceIanaTimeZone(tz: unknown): string | undefined {
+    const re = /^(?:\s*(?:UTC|GMT)\s*)?([+-])(\d{1,2})(?::?(\d{1,2}))?$/i;
     if (typeof tz === 'string') {
-        const raw = tz.trim();
-        if (raw === '') return fallback;
+        const raw: string = tz.trim();
+        if (raw === '') return undefined;
         // 1) IANA 名称ならそのまま
         if (isValidIanaTimeZone(raw)) return raw;
 
         // 2) UTC/GMT またはオフセット表記を Luxon が受理可能な形式 "UTC+HH:MM" に正規化
         //    許容: "+9", "+09", "+0900", "+09:00"、および先頭に "UTC"/"GMT" が付く形式
         //    例: "UTC+9", "GMT+09:00", "+09:00", "-0530"
-        const m = raw.match(/^(?:\s*(?:UTC|GMT)\s*)?([+-])(\d{1,2})(?::?(\d{1,2}))?$/i);
-        if (m) {
-            const sign = m[1] === '-' ? '-' : '+';
-            const hhNum = Number(m[2]);
-            const mmNum = m[3] ? Number(m[3]) : 0;
+        const m1 = re.exec(raw);
+        if (m1) {
+            const sign = m1[1] === '-' ? '-' : '+';
+            const hhNum = Number(m1[2]);
+            const mmNum = m1[3] ? Number(m1[3]) : 0;
             if (Number.isFinite(hhNum) && Number.isFinite(mmNum)) {
                 // 一般的な範囲チェック（IANA 固定オフセットの上限は +14:00、下限は -12:00 程度）
                 if (hhNum >= 0 && hhNum <= 14 && mmNum >= 0 && mmNum < 60) {
@@ -35,21 +36,6 @@ export function coerceIanaTimeZone(tz: unknown, fallback?: string): string | und
 
         // 3) "UTC"/"GMT" 単独は UTC と見なす
         if (/^(UTC|GMT)$/i.test(raw)) return 'UTC+00:00';
-    }
-    // 最後に fallback 側も変換を試みる
-    if (typeof fallback === 'string') {
-        const fb = fallback.trim();
-        if (fb) {
-            if (isValidIanaTimeZone(fb)) return fb;
-            const m = fb.match(/^(?:\s*(?:UTC|GMT)\s*)?([+-])(\d{1,2})(?::?(\d{1,2}))?$/i);
-            if (m) {
-                const sign = m[1] === '-' ? '-' : '+';
-                const hh = String(Number(m[2])).padStart(2, '0');
-                const mm = String(m[3] ? Number(m[3]) : 0).padStart(2, '0');
-                return `UTC${sign}${hh}:${mm}`;
-            }
-            if (/^(UTC|GMT)$/i.test(fb)) return 'UTC+00:00';
-        }
     }
     return undefined;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 非IANA固定オフセット（例: +09:00, UTC+9）とUTC/GMT表記を受け入れるタイムゾーン対応を追加。見出しやブロックに日付属性を付与し日付情報を安定伝播。

- 改良
  - ヘッダーの from/to 構文解析や時刻・タイムゾーン解析を強化し、区切り記号や am/pm 処理を改善。
  - プレビューで過去イベント判定を属性ベースに統一し、過去イベントの非表示処理とバナー表示を安定化。  

- テスト
  - NOTE系アドモニション非変換、フライト省略構文、非IANAタイムゾーンでのISO生成などの検証を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->