### PR TITLE
Consider alias imports

### DIFF
--- a/apps/studio/astro.config.mjs
+++ b/apps/studio/astro.config.mjs
@@ -21,6 +21,13 @@ export default defineConfig({
                 'decode-named-character-reference/index.dom.js': 'decode-named-character-reference/index.js',
                 // CSS import for editor package during development
                 '@itinerary-md/editor/index.css': fileURLToPath(new URL('../../packages/editor/dist/index.css', import.meta.url)),
+                // Path aliases for cleaner imports
+                '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
+                '@pages': fileURLToPath(new URL('./src/pages', import.meta.url)),
+                '@styles': fileURLToPath(new URL('./src/styles', import.meta.url)),
+                '@types': fileURLToPath(new URL('./src/types', import.meta.url)),
+                '@utils': fileURLToPath(new URL('./src/utils', import.meta.url)),
+                '@lib': fileURLToPath(new URL('./src/lib', import.meta.url)),
             },
         },
         optimizeDeps: {

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -9,6 +9,15 @@
   ],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@pages/*": ["src/pages/*"],
+      "@styles/*": ["src/styles/*"],
+      "@types/*": ["src/types/*"],
+      "@utils/*": ["src/utils/*"],
+      "@lib/*": ["src/lib/*"]
+    }
   }
 }

--- a/docs/ALIAS_IMPORTS.md
+++ b/docs/ALIAS_IMPORTS.md
@@ -1,0 +1,169 @@
+# Alias Import Conventions
+
+This document outlines the alias import conventions configured across the monorepo.
+
+## Overview
+
+Path aliases are configured to provide cleaner and more maintainable import statements across the codebase. Instead of relative imports like `../../../components/Button`, you can use `@components/Button`.
+
+## Configured Aliases
+
+### Studio App (`apps/studio`)
+
+The following aliases are available in the Studio app:
+
+- `@components/*` → `src/components/*`
+- `@pages/*` → `src/pages/*`
+- `@styles/*` → `src/styles/*`
+- `@types/*` → `src/types/*`
+- `@utils/*` → `src/utils/*`
+- `@lib/*` → `src/lib/*`
+
+#### Example Usage
+
+```typescript
+// Before
+import Header from '../components/Header.astro';
+import { formatDate } from '../../utils/date';
+
+// After
+import Header from '@components/Header.astro';
+import { formatDate } from '@utils/date';
+```
+
+### Editor Package (`packages/editor`)
+
+The following aliases are available in the Editor package:
+
+- `@components/*` → `src/components/*`
+- `@hooks/*` → `src/hooks/*`
+- `@utils/*` → `src/utils/*`
+- `@types/*` → `src/types/*`
+- `@lib/*` → `src/lib/*`
+
+Additionally, for development:
+- `remark-itinerary` → `../core/src`
+- `remark-itinerary-alert` → `../alert/src`
+
+#### Example Usage
+
+```typescript
+// Before
+import { useAutosave } from '../../hooks/useAutosave';
+import Button from '../components/Button';
+
+// After
+import { useAutosave } from '@hooks/useAutosave';
+import Button from '@components/Button';
+```
+
+### Core Package (`packages/core`)
+
+The following aliases are available in the Core package:
+
+- `@utils/*` → `src/utils/*`
+- `@types/*` → `src/types/*`
+- `@lib/*` → `src/lib/*`
+
+## Configuration Files
+
+### TypeScript Configuration
+
+Each package has its own `tsconfig.json` with the following structure:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      // ... other aliases
+    }
+  }
+}
+```
+
+### Build Tool Configuration
+
+#### Astro/Vite (Studio App)
+
+Configured in `astro.config.mjs`:
+
+```javascript
+vite: {
+  resolve: {
+    alias: {
+      '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
+      // ... other aliases
+    }
+  }
+}
+```
+
+#### Vite (Editor Package)
+
+Configured in `vite.config.ts`:
+
+```javascript
+resolve: {
+  alias: {
+    '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
+    // ... other aliases
+  }
+}
+```
+
+## Best Practices
+
+1. **Use aliases for internal imports**: Always use alias imports when importing from within the same package.
+
+2. **Consistency**: Use the same alias pattern across all packages for similar directories (e.g., `@components`, `@utils`).
+
+3. **Avoid circular dependencies**: Be careful when using aliases to not create circular dependencies between modules.
+
+4. **IDE Support**: Ensure your IDE/editor recognizes the TypeScript path mappings for proper IntelliSense support.
+
+5. **New directories**: When adding new directories that should have aliases, update both the TypeScript config and the build tool config.
+
+## Migration Guide
+
+To migrate existing code to use alias imports:
+
+1. Identify relative imports in your code
+2. Replace them with the appropriate alias
+3. Run TypeScript checking to ensure all imports resolve correctly
+4. Test the build to ensure bundling works correctly
+
+### Example Migration
+
+```typescript
+// Old import
+import { Button } from '../../../components/ui/Button';
+import { useDebounce } from '../../hooks/useDebounce';
+import type { User } from '../../../types/user';
+
+// New import
+import { Button } from '@components/ui/Button';
+import { useDebounce } from '@hooks/useDebounce';
+import type { User } from '@types/user';
+```
+
+## Troubleshooting
+
+### Import not resolving
+
+1. Check that the alias is configured in both `tsconfig.json` and the build tool config
+2. Ensure the path is correct relative to the base URL
+3. Restart your development server after configuration changes
+
+### TypeScript errors
+
+1. Ensure `baseUrl` is set correctly in `tsconfig.json`
+2. Check that the `paths` mapping matches your directory structure
+3. Run `npm run typecheck` to verify TypeScript configuration
+
+### Build errors
+
+1. Verify that the build tool configuration matches the TypeScript configuration
+2. Check that all file paths use the correct URL resolution
+3. Clear build cache if necessary

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.build.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@utils/*": ["src/utils/*"],
+            "@types/*": ["src/types/*"],
+            "@lib/*": ["src/lib/*"]
+        }
+    },
+    "include": ["src", "test"]
+}

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -11,7 +11,12 @@
             "remark-itinerary": ["../core/src"],
             "remark-itinerary/*": ["../core/src/*"],
             "remark-itinerary-alert": ["../alert/src"],
-            "remark-itinerary-alert/*": ["../alert/src/*"]
+            "remark-itinerary-alert/*": ["../alert/src/*"],
+            "@components/*": ["src/components/*"],
+            "@hooks/*": ["src/hooks/*"],
+            "@utils/*": ["src/utils/*"],
+            "@types/*": ["src/types/*"],
+            "@lib/*": ["src/lib/*"]
         },
         "allowImportingTsExtensions": true,
         "resolveJsonModule": true,

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -8,12 +8,19 @@ export default defineConfig(({ command }) => {
     return {
         plugins: [react(), tailwindcss()],
         resolve: {
-            alias: isServe
-                ? {
-                      'remark-itinerary': fileURLToPath(new URL('../core/src', import.meta.url)),
-                      'remark-itinerary-alert': fileURLToPath(new URL('../alert/src', import.meta.url)),
-                  }
-                : {},
+            alias: {
+                ...(isServe
+                    ? {
+                          'remark-itinerary': fileURLToPath(new URL('../core/src', import.meta.url)),
+                          'remark-itinerary-alert': fileURLToPath(new URL('../alert/src', import.meta.url)),
+                      }
+                    : {}),
+                '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
+                '@hooks': fileURLToPath(new URL('./src/hooks', import.meta.url)),
+                '@utils': fileURLToPath(new URL('./src/utils', import.meta.url)),
+                '@types': fileURLToPath(new URL('./src/types', import.meta.url)),
+                '@lib': fileURLToPath(new URL('./src/lib', import.meta.url)),
+            },
         },
         build: {
             lib: {


### PR DESCRIPTION
Configure alias imports across the monorepo to improve import readability and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-83da651d-d8ef-4863-b548-81683dca9ed1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83da651d-d8ef-4863-b548-81683dca9ed1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

