### PR TITLE
価格パーサー強化、エディタ機能追加、レンダリング再構成、i18n更新、0.3.1

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -12,7 +12,7 @@
     "@astrojs/react": "^4.3.0",
     "@astrojs/sitemap": "^3.5.1",
     "@astrojs/vercel": "^8.2.7",
-    "@itinerary-md/editor": "^0.2.2",
+    "@itinerary-md/editor": "^0.3.0",
     "@sentry/astro": "^10.10.0",
     "@sentry/react": "^10.10.0",
     "@tailwindcss/vite": "^4.1.13",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -12,7 +12,7 @@
     "@astrojs/react": "^4.3.0",
     "@astrojs/sitemap": "^3.5.1",
     "@astrojs/vercel": "^8.2.7",
-    "@itinerary-md/editor": "^0.3.0",
+    "@itinerary-md/editor": "^0.3.1",
     "@sentry/astro": "^10.10.0",
     "@sentry/react": "^10.10.0",
     "@tailwindcss/vite": "^4.1.13",

--- a/apps/studio/public/sample_en.md
+++ b/apps/studio/public/sample_en.md
@@ -16,6 +16,8 @@ timezone: Asia/Tokyo
 
 TripMD is a framework that leverages the simplicity and flexibility of Markdown to write and share travel itineraries in structured text.
 
+TripMD consists of the Studio (editor) and the underlying Remark plugins.
+
 - ✈️ **Organize flights, accommodations, sightseeing, and transportation** chronologically
 - 🌍 **Timezone-aware** time management
 - 💰 **Expense tracking** with multi-currency support
@@ -24,12 +26,12 @@ TripMD is a framework that leverages the simplicity and flexibility of Markdown 
 
 ## 2026-01-23
 
-> [08:50@Asia/Tokyo] - [16:35@Europe/Paris] flight AF187 from HND to CDG
+> [08:50@Asia/Tokyo] - [16:35@Europe/Paris] flight AF187 from Haneda Airport^HND to Charles de Gaulle Airport^CDG
 >
 > - price: 285000 JPY
 > - class: Economy
 > - seat: 32A
-> - note: Online check-in completed
+> - note: Check in 2 hours before
 
 > [18:30@Europe/Paris] train RER B :: CDG - Châtelet
 >
@@ -40,32 +42,28 @@ TripMD is a framework that leverages the simplicity and flexibility of Markdown 
 >
 > - price: EUR 2.10
 
-> [!CAUTION]
+> [!CAUTION] Power adapter preparation
 >
-> Power adapter preparation
 > France uses Type C/E plugs.
-> Japanese Type A plugs cannot be used.
 
 > [19:30@Europe/Paris] hotel :: [Example Hotel Paris](https://example.com/hotel)
 >
 > - check-in: 15:00
 > - check-out: 11:00
-> - price: EUR 180/night
+> - price: EUR {80*2}
 > - wifi: Available
-> - note: Breakfast included
 
-> [20:30@Europe/Paris] dinner :: [Bistro Example](https://example.com/bistro)
+> [20:30@Europe/Paris] dinner French cuisine :: Restaurant Example
 >
 > - price: EUR 45
 
 ## 2026-01-24 @Europe/Paris
 
-> [!TIP] Avoiding museum crowds
+> [!TIP] Museum tickets
 >
-> Purchase museum tickets online in advance to
-> skip long queues. Also download the official apps.
+> Purchase museum tickets online in advance
 
-> [09:00] breakfast :: [Hotel Restaurant](https://example.com/hotel)
+> [09:00] breakfast :: Hotel
 
 > [10:30] - [13:00] museum :: [Louvre Museum](https://example.com/louvre)
 >
@@ -84,7 +82,6 @@ TripMD is a framework that leverages the simplicity and flexibility of Markdown 
 > [15:00] - [17:00] sightseeing :: Eiffel Tower
 >
 > - price: EUR 26.80
-> - note: Up to 2nd floor
 
 > [18:30] dinner :: [Le Example Restaurant](https://example.com/restaurant)
 >
@@ -106,13 +103,15 @@ A systematic explanation of TripMD syntax.
 All events are written in quote blocks starting with `>`.
 
 ```markdown
-> [time] eventType title :: location/details
+> [time] eventType title^alias :: location/details^alias
 > - attribute: value
 ```
 
 ## 2. Event Types
 
 Event types are automatically classified into three categories:
+
+`title^alias` notation allows writing local names or alternate labels.
 
 ### Transportation
 
@@ -186,20 +185,7 @@ All other event types:
 > [10:00] train from Tokyo to Kyoto              # from-to format
 ```
 
-### Activity
-
-```markdown
-> [14:00] museum :: [Example Museum](https://example.com)
-> - note: Using official app with `skip-the-line`
-```
-
-### Accommodation
-
-Write the accommodation name, and optionally add area or notes after `::`.
-
-```markdown
-> [15:00] hotel :: Example Paris
-```
+Spaces are required around each symbol (`::`, `-`, `from`, `to`, `at`).
 
 ## 5. Attribute Keys
 
@@ -213,6 +199,10 @@ Lines starting with `- key: value` add detailed information to events.
 > - price: EUR 100          # Price (price/cost are auto-aggregated)
 > - cost: 15000 JPY         # Cost (treated same as price)
 ```
+
+`price`, `cost` are converted and auto-aggregated.
+
+Arithmetic like `{25*4} EUR` is supported.
 
 #### Transportation
 
@@ -330,10 +320,16 @@ currency: JPY              # Document default currency
 
 # Developer Information
 
+TripMD (codename `itinerary-md`/`itmd`) is a Markdown extension for writing travel itineraries devised and developed by [@cumuloworks](https://github.com/cumuloworks).
+
+The TripMD Studio app is published in `apps/studio` for demonstration purposes.
+
+The packages include the core Remark parser (`remark-itinerary`), the alert extension (`remark-itinerary-alert`), and the editor component (`@itinerary-md/editor`).
+
 ## Installation and Basic Setup
 
 ```bash
-npm install remark-itinerary
+npm install remark-itinerary remark-itinerary-alert
 ```
 
 ```typescript
@@ -434,9 +430,11 @@ function ItineraryViewer({ markdown }) {
 - **remark-itinerary** - Core parser (MIT License)
 - **remark-itinerary-alert** - Alert extension (MIT License)
 - **@itinerary-md/editor** - React editor component (UNLICENSED)
+- **@itinerary-md/studio** - Studio app (UNLICENSED)
 
 ## Resources
 
 - GitHub: [cumuloworks/itinerary-md](https://github.com/cumuloworks/itinerary-md)  
 - Demo: [https://tripmd.dev/](https://tripmd.dev/)
 - npm: [remark-itinerary](https://www.npmjs.com/package/remark-itinerary)
+- npm: [remark-itinerary-alert](https://www.npmjs.com/package/remark-itinerary-alert)

--- a/apps/studio/public/sample_ja.md
+++ b/apps/studio/public/sample_ja.md
@@ -3,10 +3,10 @@ type: tripmd
 title: TripMD へようこそ
 description: TripMD (itinerary-md) は旅行の行程を Markdown で記述・共有するためのフレームワークです。
 tags:
-  - イントロダクション
-  - サンプル
-  - 日本
-  - パリ
+ - イントロダクション
+ - サンプル
+ - 日本
+ - パリ
 budget: 750000 JPY
 currency: JPY
 timezone: Asia/Tokyo
@@ -16,20 +16,22 @@ timezone: Asia/Tokyo
 
 TripMD は、Markdown のシンプルさと柔軟性を活かして、旅行の行程を構造化されたテキストで記述・共有できるフレームワークです。
 
-- ✈️ **フライト・宿泊・観光・交通** を時系列で整理
-- 🌍 **タイムゾーン** を意識した時刻管理
-- 💰 **費用の記録** と複数通貨対応
+Studio(エディタ)と、その基盤となるRemarkプラグインから構成されており、
+
+- ✈️ **フライト・宿泊・観光・交通** など旅行特有のイベントを整理
+- 🌍 **タイムゾーン** を加味した時間管理
+- 💰 **費用の試算と記録** と複数通貨の対応
 
 # 使用例
 
 ## 2026-01-23
 
-> [08:50@Asia/Tokyo] - [16:35@Europe/Paris] flight AF187 from HND to CDG
+> [08:50@Asia/Tokyo] - [16:35@Europe/Paris] flight AF187 from 羽田空港^HND to シャルル・ド・ゴール空港^CDG
 >
 > - price: 285000 JPY
 > - class: Economy
 > - seat: 32A
-> - note: オンラインチェックイン済み
+> - note: 2時間前にチェックイン
 
 > [18:30@Europe/Paris] train RER B :: CDG - Châtelet
 >
@@ -40,32 +42,28 @@ TripMD は、Markdown のシンプルさと柔軟性を活かして、旅行の�
 >
 > - price: EUR 2.10
 
-> [!CAUTION]
+> [!CAUTION] 電源プラグの準備
 >
-> 電源プラグの準備
-> フランスではタイプC/Eのプラグが必要です。
-> 日本のタイプAプラグは使用できません。
+> フランスではタイプC/Eのプラグが必要。
 
 > [19:30@Europe/Paris] hotel :: [Example Hotel Paris](https://example.com/hotel)
 >
 > - check-in: 15:00
 > - check-out: 11:00
-> - price: EUR 180/night
+> - price: EUR {80*2}
 > - wifi: あり
-> - note: 朝食付き
 
-> [20:30@Europe/Paris] dinner :: [Bistro Example](https://example.com/bistro)
+> [20:30@Europe/Paris] dinner フランス料理 :: Restaurant Example
 >
 > - price: EUR 45
 
 ## 2026-01-24 @Europe/Paris
 
-> [!TIP] 美術館の混雑回避
+> [!TIP] 美術館チケット
 >
-> 美術館のチケットは事前にオンライン購入することで、
-> 長い行列を避けられます。公式アプリもダウンロードしておきましょう。
+> 美術館のチケットは事前にオンライン購入する
 
-> [09:00] breakfast :: [ホテルレストラン](https://example.com/hotel)
+> [09:00] breakfast :: ホテル
 
 > [10:30] - [13:00] museum :: [ルーヴル美術館](https://example.com/louvre)
 >
@@ -76,15 +74,9 @@ TripMD は、Markdown のシンプルさと柔軟性を活かして、旅行の�
 >
 > - price: EUR 25
 
-> [!WARNING] 交通機関のストライキ
->
-> フランスでは交通機関のストライキが頻繁に発生します。
-> 移動前に運行情報を確認しましょう。
-
 > [15:00] - [17:00] sightseeing :: エッフェル塔
 >
 > - price: EUR 26.80
-> - note: 第2展望台まで
 
 > [18:30] dinner :: [Le Example Restaurant](https://example.com/restaurant)
 >
@@ -106,35 +98,37 @@ TripMD の文法を体系的に説明します。
 すべてのイベントは `>` で始まる引用ブロックで記述します。
 
 ```markdown
-> [時刻] イベントタイプ タイトル :: 場所/詳細
+> [時刻] イベントタイプ タイトル^別名 :: 場所・ルート^別名
 > - 属性: 値
 ```
 
 ## 2. イベントタイプ
 
-イベントタイプは3つのカテゴリに自動分類されます：
+イベントタイプは主に3種類あり、タイトルをつけることができます。
+
+`タイトル^別名`の記法をすることで、現地語表記などを書くことができます。
 
 ### 交通 (Transportation)
 
 ```markdown
-> [10:00] flight AF187 :: HND - CDG          # フライト
-> [14:00] train :: 東京駅 - 京都駅            # 電車
-> [15:30] bus :: 空港 - ホテル                # バス  
-> [16:00] taxi :: レストラン - ホテル          # タクシー
-> [09:00] subway :: Châtelet - Louvre         # 地下鉄
-> [10:00] ferry :: 本島 - 離島                # フェリー
-> [11:00] drive :: レンタカーで移動           # ドライブ
-> [12:00] cablecar :: 山頂駅へ                # ケーブルカー
+> [10:00] flight AF187 :: HND - CDG # フライト
+> [14:00] train :: 東京駅 - 京都駅 # 電車
+> [15:30] bus :: 空港 - ホテル # バス 
+> [16:00] taxi :: レストラン - ホテル # タクシー
+> [09:00] subway :: Châtelet - Louvre # 地下鉄
+> [10:00] ferry :: 本島 - 離島 # フェリー
+> [11:00] drive :: レンタカーで移動 # ドライブ
+> [12:00] cablecar :: 山頂駅へ # ケーブルカー
 ```
 
 ### 宿泊 (Stay)
 
 ```markdown
-> [15:00] hotel :: [Example Hotel](https://example.com)    # ホテル
-> [18:00] ryokan :: 温泉旅館                               # 旅館
-> [14:00] hostel :: ユースホステル                         # ホステル
-> [16:00] dormitory :: ゲストハウス                        # ドミトリー
-> [15:00] stay :: 友人宅                                  # 汎用的な宿泊
+> [15:00] hotel :: [Example Hotel](https://example.com) # ホテル
+> [18:00] ryokan :: 温泉旅館 # 旅館
+> [14:00] hostel :: ユースホステル # ホステル
+> [16:00] dormitory :: ゲストハウス # ドミトリー
+> [15:00] stay :: 友人宅 # 汎用的な宿泊
 ```
 
 ### アクティビティ (Activity)
@@ -142,13 +136,13 @@ TripMD の文法を体系的に説明します。
 上記以外のすべてのイベントタイプ：
 
 ```markdown
-> [10:00] museum :: ルーヴル美術館           # 美術館
-> [12:00] lunch :: イタリアンレストラン       # 昼食
-> [14:00] sightseeing :: エッフェル塔         # 観光
-> [09:00] breakfast                       # 朝食（タイトル省略可）
-> [15:00] shopping :: デパート                # 買い物
-> [16:00] cafe :: カフェで休憩                # カフェ
-> [20:00] dinner :: レストラン予約            # 夕食
+> [10:00] museum :: ルーヴル美術館 # 美術館
+> [12:00] lunch :: イタリアンレストラン # 昼食
+> [14:00] sightseeing :: エッフェル塔 # 観光
+> [09:00] breakfast # 朝食（タイトル省略可）
+> [15:00] shopping :: デパート # 買い物
+> [16:00] cafe :: カフェで休憩 # カフェ
+> [20:00] dinner :: レストラン予約 # 夕食
 ```
 
 ## 3. 時刻の記法
@@ -156,52 +150,39 @@ TripMD の文法を体系的に説明します。
 ### 具体的な時刻
 
 ```markdown
-> [09:00] breakfast          # 基本形
-> [09:00@Asia/Tokyo] lunch   # タイムゾーン付き
-> [09:00] - [11:30] meeting  # 時間範囲
-> [09:00+1] arrival          # 翌日を示す +1
+> [09:00] breakfast # 基本形
+> [09:00@Asia/Tokyo] lunch # タイムゾーン付き
+> [09:00] - [11:30] meeting # 時間範囲
+> [09:00+1] arrival # 翌日を示す +1
 ```
 
 ### 大まかな時間帯
 
 ```markdown
-> [am] activity   # 午前
-> [pm] cafe       # 午後
-> [] sightseeing  # 時刻未定
+> [am] activity # 午前
+> [pm] cafe # 午後
+> [] sightseeing # 時刻未定
 ```
 
 ## 4. 場所の記法
 
-### 単一の場所
+### 場所
 
 ```markdown
-> [10:00] museum :: ルーヴル美術館
-> [15:00] cafe :: [Café Example](https://example.com)
+> [10:00] museum :: ルーヴル美術館 # ダブルコロン形式
+> [15:00] cafe at [Café Example](https://example.com) # at 形式
 ```
 
-### 移動（A地点からB地点）
+### 移動
 
 ```markdown
-> [08:00] flight :: NRT - CDG                    # ダッシュ形式
-> [10:00] train from Tokyo to Kyoto              # from-to 形式
+> [08:00] flight :: NRT - CDG # ダッシュ形式
+> [10:00] train from Tokyo to Kyoto # from-to 形式
 ```
 
-### アクティビティ
+それぞれの記号(`::`, `-`, `from`, `to`, `at`)の前後にはスペースが必要です。
 
-```markdown
-> [14:00] museum :: [Example Museum](https://example.com)
-> - note: 公式アプリを利用し `skip-the-line` を使用
-```
-
-### 宿泊
-
-宿泊先の名称を書き、必要に応じて `::` の後にエリアやメモを追記します。
-
-```markdown
-> [15:00] hotel :: Example Paris
-```
-
-## 5. 属性キー
+## 5. 属性(メタデータ)
 
 `- key: value` で始まる行で、イベントに詳細情報を追加できます。
 
@@ -210,39 +191,45 @@ TripMD の文法を体系的に説明します。
 #### 料金関連
 
 ```markdown
-> - price: EUR 100          # 価格（price/costは自動集計される）
-> - cost: 15000 JPY         # 費用（priceと同様に扱われる）
+> - price: EUR 100
+> - cost: 15000 JPY
 ```
+
+`price`, `cost`は通貨の変換・自動集計が行われます。
+
+`{25*4} EUR`のような表記で四則演算が可能です。
 
 #### 交通関連
 
 ```markdown
-> - class: Economy          # 座席クラス
-> - seat: 32A               # 座席番号
-> - duration: 2h 30m        # 所要時間
-> - platform: 5             # プラットフォーム
-> - gate: 42                # ゲート番号
+> - class: Economy # 座席クラス
+> - seat: 32A # 座席番号
+> - duration: 2h 30m # 所要時間
+> - platform: 5 # プラットフォーム
+> - gate: 42 # ゲート番号
 ```
 
 #### 宿泊関連
 
 ```markdown
-> - check-in: 15:00         # チェックイン時刻
-> - check-out: 11:00        # チェックアウト時刻
-> - room: デラックスツイン   # 部屋タイプ
-> - wifi: あり              # WiFi有無
-> - breakfast: 込み         # 朝食付き
+> - check-in: 15:00 # チェックイン時刻
+> - check-out: 11:00 # チェックアウト時刻
+> - room: デラックスツイン # 部屋タイプ
+> - wifi: あり # WiFi有無
+> - breakfast: 込み # 朝食付き
 ```
 
 #### 予約・備考
 
 ```markdown
-> - reservation: 要予約     # 予約情報
+> - reservation: 要予約 # 予約情報
 > - url: https://example.com # 関連URL
-> - note: 雨天中止          # 備考・注意事項
-> - menu: コース料理        # メニュー
-> - tel: 03-1234-5678       # 電話番号
+> - note: 雨天中止 # 備考・注意事項
+> - menu: コース料理 # メニュー
+> - tel: 03-1234-5678 # 電話番号
 ```
+
+他にも、自由に文章を記述することが可能です。
 
 ## 6. アラート
 
@@ -272,31 +259,31 @@ TripMD の文法を体系的に説明します。
 
 1. **イベント個別指定** - 最優先
 
-   ```markdown
-   > [09:00@Asia/Tokyo] departure :: 成田空港
-   ```
+ ```markdown
+ > [09:00@Asia/Tokyo] departure :: 成田空港
+ ```
 
-2. **日付見出し指定** - その日のデフォルト
+1. **日付見出し指定** - その日のデフォルト
 
-   ```markdown
-   ## 2026-01-24 @Europe/Paris
+ ```markdown
+ ## 2026-01-24 @Europe/Paris
 
-   > [09:00] breakfast     # Europe/Paris として解釈
-   ```
+ > [09:00] breakfast # Europe/Paris として解釈
+ ```
 
-3. **フロントマター** - ドキュメント全体のデフォルト
+1. **フロントマター** - ドキュメント全体のデフォルト
 
-   ```yaml
-   ---
-   timezone: Asia/Tokyo
-   ---
-   ```
+ ```yaml
+ ---
+ timezone: Asia/Tokyo
+ ---
+ ```
 
-4. **プラグインオプション** - 処理時の設定
+1. **プラグインオプション** - 処理時の設定
 
-   ```typescript
-   .use(remarkItinerary, { defaultTimezone: 'Asia/Tokyo' })
-   ```
+ ```typescript
+ .use(remarkItinerary, { defaultTimezone: 'Asia/Tokyo' })
+ ```
 
 ### 通貨の処理
 
@@ -304,15 +291,15 @@ TripMD の文法を体系的に説明します。
 
 ```yaml
 ---
-currency: JPY              # ドキュメントのデフォルト通貨
+currency: JPY # ドキュメントのデフォルト通貨
 ---
 ```
 
 ```markdown
 > [10:00] lunch ::
-> - price: 1500            # JPY として解釈される
-> - price: EUR 25          # 明示的に EUR を指定
-> - price: $30             # USD として解釈される
+> - price: 1500 # JPY として解釈される
+> - price: EUR 25 # 明示的に EUR を指定
+> - price: $30 # USD として解釈される
 ```
 
 ### 時刻の曖昧な表現
@@ -321,8 +308,8 @@ currency: JPY              # ドキュメントのデフォルト通貨
 
 ```typescript
 .use(remarkItinerary, {
-  amHour: 9,    // [am] = 09:00
-  pmHour: 15    // [pm] = 15:00
+ amHour: 9, // [am] = 09:00
+ pmHour: 15 // [pm] = 15:00
 })
 ```
 
@@ -330,10 +317,16 @@ currency: JPY              # ドキュメントのデフォルト通貨
 
 # 開発者向け情報
 
+TripMD(コードネーム`itinerary-md`/`itmd`)は [@cumuloworks](https://github.com/cumuloworks) によって考案・開発された旅程を記述するためのマークダウン拡張です。
+
+このTripMD Studioアプリは、そのデモンストレーションのために`apps/studio`で公開されています。
+
+パッケージには、基盤となるRemarkパーサー(`remark-itinerary`)、アラート記法用のRemarkパーサー(`remark-itinerary-alert`)、エディター本体(`@itinerary-md/editor`)が含まれます。
+
 ## インストールと基本設定
 
 ```bash
-npm install remark-itinerary
+npm install remark-itinerary remark-itinerary-alert
 ```
 
 ```typescript
@@ -343,14 +336,14 @@ import remarkItinerary from 'remark-itinerary';
 import remarkItineraryAlert from 'remark-itinerary-alert';
 
 const processor = unified()
-  .use(remarkParse)
-  .use(remarkItineraryAlert)      // アラート機能を追加（remarkItineraryより先に実行する必要があります）
-  .use(remarkItinerary, {
-    defaultTimezone: 'Asia/Tokyo',      // デフォルトタイムゾーン
-    defaultCurrency: 'JPY',       // デフォルト通貨
-    amHour: 9,                     // [am] の時刻
-    pmHour: 15                     // [pm] の時刻
-  });
+ .use(remarkParse)
+ .use(remarkItineraryAlert) // アラート機能を追加（remarkItineraryにより日付属性を付与するため、remarkItineraryより先に実行する必要があります）
+ .use(remarkItinerary, {
+ defaultTimezone: 'Asia/Tokyo', // デフォルトタイムゾーン
+ defaultCurrency: 'JPY', // デフォルト通貨
+ amHour: 9, // [am] の時刻
+ pmHour: 15 // [pm] の時刻
+ });
 ```
 
 ## AST ノード構造
@@ -359,19 +352,19 @@ remark-itinerary は Markdown AST に以下のカスタムノードを追加し�
 
 ```typescript
 interface ITMDEventNode {
-  type: 'itmdEvent';
-  eventType: string;                    // 'flight', 'hotel' など
-  baseType: 'transportation' | 'stay' | 'activity';
-  time?: {
-    kind: 'none' | 'marker' | 'point' | 'range';
-    // ... 時刻情報
-  };
-  title?: RichInline | null;           // イベントタイトル
-  destination?: {                      // 場所情報
-    kind: 'single' | 'dashPair' | 'fromTo';
-    // ... 場所詳細
-  };
-  body?: ITMDBodySegment[];            // 属性情報など
+ type: 'itmdEvent';
+ eventType: string; // 'flight', 'hotel' など
+ baseType: 'transportation' | 'stay' | 'activity';
+ time?: {
+ kind: 'none' | 'marker' | 'point' | 'range';
+ // ... 時刻情報
+ };
+ title?: RichInline | null; // イベントタイトル
+ destination?: { // 場所情報
+ kind: 'single' | 'dashPair' | 'fromTo';
+ // ... 場所詳細
+ };
+ body?: ITMDBodySegment[]; // 属性情報など
 }
 ```
 
@@ -381,29 +374,29 @@ interface ITMDEventNode {
 import { visit } from 'unist-util-visit';
 
 const customPlugin = () => {
-  return (tree) => {
-    visit(tree, 'itmdEvent', (node) => {
-      // イベントノードを処理
-      if (node.eventType === 'flight') {
-        // フライト情報を抽出
-        console.log('Flight found:', node.title);
-      }
-      
-      // price 属性を集計
-      if (node.body) {
-        const prices = node.data?.itmdPrice || [];
-        prices.forEach(p => {
-          console.log('Price:', p.price);
-        });
-      }
-    });
-  };
+ return (tree) => {
+ visit(tree, 'itmdEvent', (node) => {
+ // イベントノードを処理
+ if (node.eventType === 'flight') {
+ // フライト情報を抽出
+ console.log('Flight found:', node.title);
+ }
+ 
+ // price 属性を集計
+ if (node.body) {
+ const prices = node.data?.itmdPrice || [];
+ prices.forEach(p => {
+ console.log('Price:', p.price);
+ });
+ }
+ });
+ };
 };
 ```
 
 ## React での使用例
 
-```tsx
+```typescript
 import { useMemo } from 'react';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
@@ -413,19 +406,19 @@ import remarkRehype from 'remark-rehype';
 import rehypeReact from 'rehype-react';
 
 function ItineraryViewer({ markdown }) {
-  const content = useMemo(() => {
-    const processor = unified()
-      .use(remarkParse)
+ const content = useMemo(() => {
+ const processor = unified()
+ .use(remarkParse)
 // remarkItineraryAlert should come first
-      .use(remarkItineraryAlert)
-      .use(remarkItinerary)
-      .use(remarkRehype)
-      .use(rehypeReact, { createElement: React.createElement });
-    
-    return processor.processSync(markdown).result;
-  }, [markdown]);
-  
-  return <div>{content}</div>;
+ .use(remarkItineraryAlert)
+ .use(remarkItinerary)
+ .use(remarkRehype)
+ .use(rehypeReact, { createElement: React.createElement });
+ 
+ return processor.processSync(markdown).result;
+ }, [markdown]);
+ 
+ return <div>{content}</div>;
 }
 ```
 
@@ -434,9 +427,11 @@ function ItineraryViewer({ markdown }) {
 - **remark-itinerary** - コアパーサー (MITライセンス)
 - **remark-itinerary-alert** - アラート拡張 (MITライセンス)
 - **@itinerary-md/editor** - React エディタコンポーネント (UNLICENSED)
+- **@itinerary-md/studio**- Studioアプリ (UNLICENSED)
 
 ## リソース
 
-- GitHub: [cumuloworks/itinerary-md](https://github.com/cumuloworks/itinerary-md)  
+- GitHub: [cumuloworks/itinerary-md](https://github.com/cumuloworks/itinerary-md)
 - デモ: [https://tripmd.dev/](https://tripmd.dev/)
 - npm: [remark-itinerary](https://www.npmjs.com/package/remark-itinerary)
+- npm: [remark-itinerary-alert](https://www.npmjs.com/package/remark-itinerary-alert)

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "@astrojs/react": "^4.3.0",
                 "@astrojs/sitemap": "^3.5.1",
                 "@astrojs/vercel": "^8.2.7",
-                "@itinerary-md/editor": "^0.2.2",
+                "@itinerary-md/editor": "^0.3.0",
                 "@sentry/astro": "^10.10.0",
                 "@sentry/react": "^10.10.0",
                 "@tailwindcss/vite": "^4.1.13",
@@ -18338,7 +18338,7 @@
         },
         "packages/core": {
             "name": "remark-itinerary",
-            "version": "0.2.2",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "expr-eval": "^2.0.2",
@@ -18363,7 +18363,7 @@
         },
         "packages/editor": {
             "name": "@itinerary-md/editor",
-            "version": "0.2.2",
+            "version": "0.3.0",
             "license": "UNLICENSED",
             "dependencies": {
                 "@monaco-editor/react": "^4.7.0",
@@ -18389,7 +18389,7 @@
                 "rehype-react": "^8.0.0",
                 "remark-gfm": "^4.0.1",
                 "remark-github-blockquote-alert": "^2.0.0",
-                "remark-itinerary": "^0.2.2",
+                "remark-itinerary": "^0.3.0",
                 "remark-itinerary-alert": "^0.2.2",
                 "remark-parse": "^11.0.0",
                 "remark-rehype": "^11.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "@astrojs/react": "^4.3.0",
                 "@astrojs/sitemap": "^3.5.1",
                 "@astrojs/vercel": "^8.2.7",
-                "@itinerary-md/editor": "^0.3.0",
+                "@itinerary-md/editor": "^0.3.1",
                 "@sentry/astro": "^10.10.0",
                 "@sentry/react": "^10.10.0",
                 "@tailwindcss/vite": "^4.1.13",
@@ -18338,7 +18338,7 @@
         },
         "packages/core": {
             "name": "remark-itinerary",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "expr-eval": "^2.0.2",
@@ -18363,7 +18363,7 @@
         },
         "packages/editor": {
             "name": "@itinerary-md/editor",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "UNLICENSED",
             "dependencies": {
                 "@monaco-editor/react": "^4.7.0",
@@ -18389,7 +18389,7 @@
                 "rehype-react": "^8.0.0",
                 "remark-gfm": "^4.0.1",
                 "remark-github-blockquote-alert": "^2.0.0",
-                "remark-itinerary": "^0.3.0",
+                "remark-itinerary": "^0.3.1",
                 "remark-itinerary-alert": "^0.2.2",
                 "remark-parse": "^11.0.0",
                 "remark-rehype": "^11.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9239,6 +9239,12 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/expr-eval": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
+            "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==",
+            "license": "MIT"
+        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -18335,6 +18341,7 @@
             "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
+                "expr-eval": "^2.0.2",
                 "luxon": "^3.7.1",
                 "mdast-util-to-string": "4.0.0",
                 "unist-util-visit": "^5.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "remark-itinerary",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "private": false,
     "type": "module",
     "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,8 @@
     "dependencies": {
         "luxon": "^3.7.1",
         "mdast-util-to-string": "4.0.0",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.0.0",
+        "expr-eval": "^2.0.2"
     },
     "peerDependencies": {
         "unified": "^11.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "remark-itinerary",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "private": false,
     "type": "module",
     "license": "MIT",

--- a/packages/core/src/domain/__tests__/price.test.ts
+++ b/packages/core/src/domain/__tests__/price.test.ts
@@ -41,11 +41,59 @@ describe('itmd/price normalizePriceLine', () => {
         expect(money.normalized.amount).toBe('100');
     });
 
+    it('accepts no-space tail code: "24EUR"', () => {
+        const node = normalizePriceLine('24EUR');
+        const money = node.tokens[0] as Extract<(typeof node.tokens)[number], { kind: 'money' }>;
+        expect(money.normalized.currency).toBe('EUR');
+        expect(money.normalized.amount).toBe('24');
+    });
+
+    it('accepts no-space head code: "EUR24"', () => {
+        const node = normalizePriceLine('EUR24');
+        const money = node.tokens[0] as Extract<(typeof node.tokens)[number], { kind: 'money' }>;
+        expect(money.normalized.currency).toBe('EUR');
+        expect(money.normalized.amount).toBe('24');
+    });
+
     it('fallback: parse numbers with default currency (1.234,56 -> 1234.56)', () => {
         const node = normalizePriceLine('1.234,56', 'eur');
         const money = node.tokens[0] as Extract<(typeof node.tokens)[number], { kind: 'money' }>;
         expect(money.normalized.currency).toBe('EUR');
         expect(money.normalized.amount).toBe('1234.56');
         expect(money.meta?.source).toBe('defaultCurrency');
+    });
+
+    it('adds currency-not-detected when missing code with defaultCurrency supplied', () => {
+        const node = normalizePriceLine('24EU', 'USD');
+        // No match for currency+amount pair; falls back to number + defaultCurrency
+        const money = node.tokens[0] as Extract<(typeof node.tokens)[number], { kind: 'money' }>;
+        expect(money.normalized.currency).toBe('USD');
+        expect(money.normalized.amount).toBe('24');
+        expect(node.warnings?.includes('currency-not-detected')).toBe(true);
+    });
+
+    it('evaluates math in braces with currency after: "{25*4} EUR"', () => {
+        const node = normalizePriceLine('{25*4} EUR');
+        const money = node.tokens[0] as Extract<(typeof node.tokens)[number], { kind: 'money' }>;
+        expect(money.normalized.currency).toBe('EUR');
+        expect(money.normalized.amount).toBe('100');
+        expect(node.flags.hasMath).toBe(true);
+        expect(node.data.needsEvaluation).toBe(true);
+    });
+
+    it('evaluates math in braces with currency before: "EUR {10+5*2}"', () => {
+        const node = normalizePriceLine('EUR {10+5*2}');
+        const money = node.tokens[0] as Extract<(typeof node.tokens)[number], { kind: 'money' }>;
+        expect(money.normalized.currency).toBe('EUR');
+        expect(money.normalized.amount).toBe('20');
+        expect(node.flags.hasMath).toBe(true);
+    });
+
+    it('evaluates division and parentheses in braces: "JPY {3000/3}"', () => {
+        const node = normalizePriceLine('JPY {3000/3}');
+        const money = node.tokens[0] as Extract<(typeof node.tokens)[number], { kind: 'money' }>;
+        expect(money.normalized.currency).toBe('JPY');
+        expect(money.normalized.amount).toBe('1000');
+        expect(node.flags.hasMath).toBe(true);
     });
 });

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@itinerary-md/editor",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "private": true,
     "type": "module",
     "license": "UNLICENSED",
@@ -54,7 +54,7 @@
         "rehype-react": "^8.0.0",
         "remark-gfm": "^4.0.1",
         "remark-github-blockquote-alert": "^2.0.0",
-        "remark-itinerary": "^0.2.2",
+        "remark-itinerary": "^0.3.0",
         "remark-itinerary-alert": "^0.2.2",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@itinerary-md/editor",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "private": true,
     "type": "module",
     "license": "UNLICENSED",
@@ -54,7 +54,7 @@
         "rehype-react": "^8.0.0",
         "remark-gfm": "^4.0.1",
         "remark-github-blockquote-alert": "^2.0.0",
-        "remark-itinerary": "^0.3.0",
+        "remark-itinerary": "^0.3.1",
         "remark-itinerary-alert": "^0.2.2",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",

--- a/packages/editor/src/completions/timezone.ts
+++ b/packages/editor/src/completions/timezone.ts
@@ -1,0 +1,41 @@
+import { getTimezoneOptions } from '@/utils/timezone';
+
+/**
+ * Register timezone completion provider for Monaco.
+ * This registers suggestions for IANA timezones and common UTC offset formats
+ * when the user types '@' in MDX documents.
+ */
+export function registerTimezoneCompletion(monaco: any): void {
+    monaco.languages.registerCompletionItemProvider('mdx', {
+        triggerCharacters: ['@'],
+        provideCompletionItems: (model: any, position: any) => {
+            const textUntilPosition = model.getValueInRange({
+                startLineNumber: position.lineNumber,
+                startColumn: 1,
+                endLineNumber: position.lineNumber,
+                endColumn: position.column,
+            });
+
+            if (textUntilPosition.endsWith('@')) {
+                const timezones = getTimezoneOptions();
+                const suggestions = timezones.map((tz) => ({
+                    label: tz,
+                    kind: monaco.languages.CompletionItemKind.Value,
+                    insertText: tz,
+                    detail: 'Timezone',
+                    documentation: `IANA timezone: ${tz}`,
+                    range: {
+                        startLineNumber: position.lineNumber,
+                        endLineNumber: position.lineNumber,
+                        startColumn: position.column,
+                        endColumn: position.column,
+                    },
+                }));
+
+                return { suggestions };
+            }
+
+            return { suggestions: [] };
+        },
+    });
+}

--- a/packages/editor/src/completions/timezone.ts
+++ b/packages/editor/src/completions/timezone.ts
@@ -5,8 +5,8 @@ import { getTimezoneOptions } from '@/utils/timezone';
  * This registers suggestions for IANA timezones and common UTC offset formats
  * when the user types '@' in MDX documents.
  */
-export function registerTimezoneCompletion(monaco: any): void {
-    monaco.languages.registerCompletionItemProvider('mdx', {
+export function registerTimezoneCompletion(monaco: any): { dispose: () => void } {
+    return monaco.languages.registerCompletionItemProvider('mdx', {
         triggerCharacters: ['@'],
         provideCompletionItems: (model: any, position: any) => {
             const textUntilPosition = model.getValueInRange({

--- a/packages/editor/src/components/Editor.tsx
+++ b/packages/editor/src/components/Editor.tsx
@@ -19,6 +19,7 @@ import { writeTextToClipboard } from '@/utils/clipboard';
 import { COMMON_CURRENCIES } from '@/utils/currency';
 import { buildShareUrlFromContent } from '@/utils/hash';
 import { getTimezoneOptions } from '@/utils/timezone';
+import { sanitizeFileName } from '@/utils/url';
 
 export interface EditorProps {
     storageKey?: string;
@@ -113,6 +114,26 @@ const EditorComponent: FC<EditorProps> = ({ storageKey = STORAGE_KEY_DEFAULT, sa
         }
     }, [latestContent]);
 
+    const handleDownloadMarkdown = useCallback(() => {
+        try {
+            const nameFromTitle = (frontmatterTitle || 'itinerary').toString();
+            const safeBase = sanitizeFileName(nameFromTitle).trim() || 'itinerary';
+            const fileName = `${safeBase}.md`;
+            const blob = new Blob([latestContent.current], { type: 'text/markdown;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = fileName;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        } catch (error) {
+            console.error('Download failed:', error);
+            notifyError('Download failed');
+        }
+    }, [frontmatterTitle, latestContent]);
+
     const handleOpenClearAll = useCallback(() => {
         setPendingClearAll(true);
     }, []);
@@ -146,6 +167,7 @@ const EditorComponent: FC<EditorProps> = ({ storageKey = STORAGE_KEY_DEFAULT, sa
                 onTopbarChange={updateTopbar}
                 onCopyMarkdown={handleCopyMarkdown}
                 onShareUrl={handleShareUrl}
+                onDownloadMarkdown={handleDownloadMarkdown}
                 onLoadSample={loadSample}
                 onClearAll={handleOpenClearAll}
             />

--- a/packages/editor/src/components/MarkdownPreview.tsx
+++ b/packages/editor/src/components/MarkdownPreview.tsx
@@ -32,6 +32,7 @@ interface MarkdownPreviewProps {
     autoScroll?: boolean;
     onShowPast?: () => void;
     preferAltNames?: boolean;
+    externalContainerRef?: React.Ref<HTMLDivElement>;
 }
 
 //
@@ -56,7 +57,7 @@ const inlineToSegments = (inline?: PhrasingContent[] | null): TextSegment[] | un
 
 const segmentsToPlainText = (segments?: TextSegment[]): string | undefined => (Array.isArray(segments) ? segments.map((s) => s.text).join('') : undefined);
 
-const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone, currency, rate, showPast, title, description, tags, activeLine, autoScroll = true, onShowPast, preferAltNames }) => {
+const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone, currency, rate, showPast, title, description, tags, activeLine, autoScroll = true, onShowPast, preferAltNames, externalContainerRef }) => {
     const displayTimezone = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     const showPastEffective = typeof showPast === 'boolean' ? showPast : true;
@@ -240,6 +241,15 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
 
     const containerRef = React.useRef<HTMLDivElement | null>(null);
 
+    const setContainerRef = React.useCallback(
+        (el: HTMLDivElement | null) => {
+            containerRef.current = el;
+            if (typeof externalContainerRef === 'function') externalContainerRef(el);
+            else if (externalContainerRef && typeof externalContainerRef === 'object') (externalContainerRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+        },
+        [externalContainerRef]
+    );
+
     React.useEffect(() => {
         if (!autoScroll) return;
         if (!activeLine || !containerRef.current) return;
@@ -306,7 +316,7 @@ const MarkdownPreviewComponent: FC<MarkdownPreviewProps> = ({ content, timezone,
     }, [activeLine, autoScroll]);
 
     return (
-        <div ref={containerRef} className="markdown-preview h-full px-8 py-4 bg-white overflow-auto space-y-4">
+        <div ref={setContainerRef} className="markdown-preview h-full px-8 py-4 bg-white overflow-auto space-y-4">
             {title && <h1 className="text-4xl font-bold text-gray-900 mt-6 ml-0 tracking-tight">{title}</h1>}
             {description && <p className="text-gray-600 tracking-tight">{description}</p>}
             {Array.isArray(tags) && tags.length > 0 && <Tags tags={tags} />}

--- a/packages/editor/src/components/MonacoEditor.tsx
+++ b/packages/editor/src/components/MonacoEditor.tsx
@@ -1,5 +1,6 @@
 import Editor from '@monaco-editor/react';
 import { type FC, memo, useEffect, useRef } from 'react';
+import { registerTimezoneCompletion } from '@/completions/timezone';
 
 interface MonacoEditorProps {
     value: string;
@@ -34,6 +35,7 @@ const MonacoEditorComponent: FC<MonacoEditorProps> = ({ value, onChange, onSave,
                 onChange={handleEditorChange}
                 theme="vs-light"
                 onMount={(editor, monaco) => {
+                    registerTimezoneCompletion(monaco);
                     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
                         onSave();
                     });

--- a/packages/editor/src/components/MonacoEditor.tsx
+++ b/packages/editor/src/components/MonacoEditor.tsx
@@ -35,7 +35,10 @@ const MonacoEditorComponent: FC<MonacoEditorProps> = ({ value, onChange, onSave,
                 onChange={handleEditorChange}
                 theme="vs-light"
                 onMount={(editor, monaco) => {
-                    registerTimezoneCompletion(monaco);
+                    const tzDisposable = registerTimezoneCompletion(monaco);
+                    if ((editor as any).onDidDispose && tzDisposable?.dispose) {
+                        (editor as any).onDidDispose(() => tzDisposable.dispose());
+                    }
                     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
                         onSave();
                     });

--- a/packages/editor/src/components/TopBar.tsx
+++ b/packages/editor/src/components/TopBar.tsx
@@ -52,7 +52,7 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                     .padStart(2, '0');
                 const minsAbs = (Math.abs(offsetMinutes) % 60).toString().padStart(2, '0');
                 const signStr = offsetMinutes >= 0 ? '+' : '-';
-                const offsetLabel = `GMT${signStr}${hoursAbs}${minsAbs !== '00' ? `:${minsAbs}` : ''}`;
+                const offsetLabel = `GMT${signStr}${hoursAbs}:${minsAbs}`;
                 return {
                     tz,
                     offsetMinutes,
@@ -63,8 +63,8 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                 return {
                     tz,
                     offsetMinutes: 0,
-                    offsetLabel: 'GMT+00',
-                    label: `${tz} (GMT+00)`,
+                    offsetLabel: 'GMT+00:00',
+                    label: `${tz} (GMT+00:00)`,
                 };
             }
         };
@@ -242,20 +242,22 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                     <DropdownMenu.Portal>
                         <DropdownMenu.Content align="end" sideOffset={4} className="z-50 min-w-[160px] overflow-auto rounded-md border border-gray-200 bg-white p-1 shadow-md">
                             {onPrint && (
-                                <DropdownMenu.Item onClick={onPrint} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
+                                <DropdownMenu.Item onSelect={onPrint} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
                                     <Printer size={16} className="mr-2" />
                                     {t('menu.print')}
                                 </DropdownMenu.Item>
                             )}
-                            <DropdownMenu.Item onClick={() => onDownloadMarkdown?.()} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
-                                <Download size={16} className="mr-2" />
-                                {t('menu.downloadMd')}
-                            </DropdownMenu.Item>
-                            <DropdownMenu.Item onClick={onLoadSample} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
+                            {onDownloadMarkdown && (
+                                <DropdownMenu.Item onSelect={() => onDownloadMarkdown()} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
+                                    <Download size={16} className="mr-2" />
+                                    {t('menu.downloadMd')}
+                                </DropdownMenu.Item>
+                            )}
+                            <DropdownMenu.Item onSelect={onLoadSample} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
                                 <FileText size={16} className="mr-2" />
                                 {t('menu.loadSample')}
                             </DropdownMenu.Item>
-                            <DropdownMenu.Item onClick={onClearAll} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100 text-red-600">
+                            <DropdownMenu.Item onSelect={onClearAll} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100 text-red-600">
                                 <Trash2 size={16} className="mr-2" />
                                 {t('menu.clearAll')}
                             </DropdownMenu.Item>

--- a/packages/editor/src/components/TopBar.tsx
+++ b/packages/editor/src/components/TopBar.tsx
@@ -2,7 +2,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import * as Toolbar from '@radix-ui/react-toolbar';
-import { ArrowLeftRight, Check, ChevronDown, ChevronsDown, Clipboard, Columns, Download, Eye, EyeOff, FileText, GlobeIcon, MoreHorizontal, PanelBottom, PanelLeft, PanelRight, PanelTop, RotateCcw, Rows, Share2, Trash2 } from 'lucide-react';
+import { ArrowLeftRight, Check, ChevronDown, Clipboard, Columns, Download, Eye, EyeOff, FileText, GlobeIcon, MoreHorizontal, PanelBottom, PanelLeft, PanelRight, PanelTop, Printer, RotateCcw, Rows, Share2, Trash2 } from 'lucide-react';
 import * as React from 'react';
 import { useI18n } from '@/i18n';
 import type { TopbarState, ViewMode } from '@/types/itinerary';
@@ -16,12 +16,13 @@ interface TopBarProps {
     onCopyMarkdown: () => void;
     onShareUrl: () => void;
     onDownloadMarkdown?: () => void;
+    onPrint?: () => void;
     onLoadSample: () => void;
     onClearAll: () => void;
     className?: string;
 }
 
-const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, currencyOptions, topbar, onTopbarChange, onCopyMarkdown, onShareUrl, onDownloadMarkdown, onLoadSample, onClearAll, className }) => {
+const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, currencyOptions, topbar, onTopbarChange, onCopyMarkdown, onShareUrl, onDownloadMarkdown, onPrint, onLoadSample, onClearAll, className }) => {
     const tzLabelId = React.useId();
     const currencyLabelId = React.useId();
     const { t, lang, setLanguage } = useI18n();
@@ -196,20 +197,7 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                     </span>
                 </Toolbar.Button>
 
-                <Toolbar.Button
-                    type="button"
-                    aria-label={!topbar.autoScroll ? t('autoScroll.enable') : t('autoScroll.disable')}
-                    title={!topbar.autoScroll ? t('autoScroll.enable') : t('autoScroll.disable')}
-                    onClick={() => onTopbarChange({ autoScroll: !topbar.autoScroll })}
-                    className={`inline-flex items-center justify-center px-2 h-full rounded-md border ${topbar.autoScroll ? 'text-white bg-gray-700 border-gray-700' : 'text-gray-700 bg-white hover:bg-gray-50 border-gray-300'}`}
-                >
-                    <ChevronsDown size={14} />
-                    <span className="text-xs ml-1">
-                        {t('autoScroll.label', {
-                            state: topbar.autoScroll ? t('past.on') : t('past.off'),
-                        })}
-                    </span>
-                </Toolbar.Button>
+                {/** Auto scroll toggle moved to PreviewPane header */}
 
                 <Toolbar.Button
                     type="button"
@@ -253,6 +241,12 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                     </DropdownMenu.Trigger>
                     <DropdownMenu.Portal>
                         <DropdownMenu.Content align="end" sideOffset={4} className="z-50 min-w-[160px] overflow-auto rounded-md border border-gray-200 bg-white p-1 shadow-md">
+                            {onPrint && (
+                                <DropdownMenu.Item onClick={onPrint} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
+                                    <Printer size={16} className="mr-2" />
+                                    {t('menu.print')}
+                                </DropdownMenu.Item>
+                            )}
                             <DropdownMenu.Item onClick={() => onDownloadMarkdown?.()} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
                                 <Download size={16} className="mr-2" />
                                 {t('menu.downloadMd')}

--- a/packages/editor/src/components/TopBar.tsx
+++ b/packages/editor/src/components/TopBar.tsx
@@ -2,7 +2,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import * as Toolbar from '@radix-ui/react-toolbar';
-import { ArrowLeftRight, Check, ChevronDown, ChevronsDown, Clipboard, Columns, Eye, EyeOff, FileText, GlobeIcon, MoreHorizontal, PanelBottom, PanelLeft, PanelRight, PanelTop, RotateCcw, Rows, Share2, Trash2 } from 'lucide-react';
+import { ArrowLeftRight, Check, ChevronDown, ChevronsDown, Clipboard, Columns, Download, Eye, EyeOff, FileText, GlobeIcon, MoreHorizontal, PanelBottom, PanelLeft, PanelRight, PanelTop, RotateCcw, Rows, Share2, Trash2 } from 'lucide-react';
 import * as React from 'react';
 import { useI18n } from '@/i18n';
 import type { TopbarState, ViewMode } from '@/types/itinerary';
@@ -15,12 +15,13 @@ interface TopBarProps {
     onTopbarChange: (patch: Partial<TopbarState>) => void;
     onCopyMarkdown: () => void;
     onShareUrl: () => void;
+    onDownloadMarkdown?: () => void;
     onLoadSample: () => void;
     onClearAll: () => void;
     className?: string;
 }
 
-const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, currencyOptions, topbar, onTopbarChange, onCopyMarkdown, onShareUrl, onLoadSample, onClearAll, className }) => {
+const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, currencyOptions, topbar, onTopbarChange, onCopyMarkdown, onShareUrl, onDownloadMarkdown, onLoadSample, onClearAll, className }) => {
     const tzLabelId = React.useId();
     const currencyLabelId = React.useId();
     const { t, lang, setLanguage } = useI18n();
@@ -252,6 +253,19 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                     </DropdownMenu.Trigger>
                     <DropdownMenu.Portal>
                         <DropdownMenu.Content align="end" sideOffset={4} className="z-50 min-w-[160px] overflow-auto rounded-md border border-gray-200 bg-white p-1 shadow-md">
+                            <DropdownMenu.Item onClick={() => onDownloadMarkdown?.()} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
+                                <Download size={16} className="mr-2" />
+                                {t('menu.downloadMd')}
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Item onClick={onLoadSample} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
+                                <FileText size={16} className="mr-2" />
+                                {t('menu.loadSample')}
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Item onClick={onClearAll} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100 text-red-600">
+                                <Trash2 size={16} className="mr-2" />
+                                {t('menu.clearAll')}
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Separator className="h-px my-1 bg-gray-200" />
                             <DropdownMenu.Sub>
                                 <DropdownMenu.SubTrigger className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
                                     <GlobeIcon size={14} className="mr-2" />
@@ -274,14 +288,6 @@ const TopBarComponent: React.FC<TopBarProps> = ({ tzSelectId, timezoneOptions, c
                                     </DropdownMenu.RadioGroup>
                                 </DropdownMenu.SubContent>
                             </DropdownMenu.Sub>
-                            <DropdownMenu.Item onClick={onLoadSample} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100">
-                                <FileText size={16} className="mr-2" />
-                                {t('menu.loadSample')}
-                            </DropdownMenu.Item>
-                            <DropdownMenu.Item onClick={onClearAll} className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-gray-100 text-red-600">
-                                <Trash2 size={16} className="mr-2" />
-                                {t('menu.clearAll')}
-                            </DropdownMenu.Item>
                         </DropdownMenu.Content>
                     </DropdownMenu.Portal>
                 </DropdownMenu.Root>

--- a/packages/editor/src/components/__tests__/MarkdownPreview.test.tsx
+++ b/packages/editor/src/components/__tests__/MarkdownPreview.test.tsx
@@ -129,4 +129,26 @@ describe('MarkdownPreview (itmd pipeline rendering)', () => {
         expect(code).not.toBeNull();
         expect(code?.textContent).toMatch('console.log(1)');
     });
+
+    it('uses primary names when preferAltNames=false (title and destination)', () => {
+        const md = `---\ntype: itmd\n---\n\n> [08:00] lunch タイトル^Title :: 店^Shop`;
+        render(<MarkdownPreview content={md} timezone={'UTC'} preferAltNames={false} />);
+        // Primary (before caret) should be shown
+        expect(screen.getByText('タイトル')).toBeInTheDocument();
+        expect(screen.getByText('店')).toBeInTheDocument();
+        // Alt should not be used as primary
+        expect(screen.queryByText('Title')).not.toBeInTheDocument();
+        expect(screen.queryByText('Shop')).not.toBeInTheDocument();
+    });
+
+    it('uses alternative names when preferAltNames=true (title and destination)', () => {
+        const md = `---\ntype: itmd\n---\n\n> [08:00] lunch タイトル^Title :: 店^Shop`;
+        render(<MarkdownPreview content={md} timezone={'UTC'} preferAltNames={true} />);
+        // Alt (after caret) should be shown
+        expect(screen.getByText('Title')).toBeInTheDocument();
+        expect(screen.getByText('Shop')).toBeInTheDocument();
+        // Primary should not appear when alt preferred
+        expect(screen.queryByText('タイトル')).not.toBeInTheDocument();
+        expect(screen.queryByText('店')).not.toBeInTheDocument();
+    });
 });

--- a/packages/editor/src/components/__tests__/Statistics.test.tsx
+++ b/packages/editor/src/components/__tests__/Statistics.test.tsx
@@ -160,8 +160,8 @@ describe('Statistics', () => {
         };
         render(<Statistics root={root} frontmatter={{ currency: 'EUR' }} />);
         const totalEl = document.querySelector('[aria-live="polite"]');
-        // When unconverted, the total display area is empty (em dash only on the right period)
-        expect(totalEl?.textContent || '').toBe('');
+        // When unconverted, UI shows an em dash in the display area
+        expect(totalEl?.textContent || '').toBe('—');
     });
 
     it('does not crash when Intl.NumberFormat throws RangeError and shows em dash if unconverted', () => {
@@ -181,8 +181,8 @@ describe('Statistics', () => {
         try {
             render(<Statistics root={root} frontmatter={{ currency: 'EUR' }} />);
             const totalEl = document.querySelector('[aria-live="polite"]');
-            // Even with formatter exceptions or unconverted values, the total display area is empty
-            expect(totalEl?.textContent || '').toBe('');
+            // Even with formatter exceptions or unconverted values, UI shows an em dash
+            expect(totalEl?.textContent || '').toBe('—');
         } finally {
             spy.mockRestore();
         }

--- a/packages/editor/src/components/__tests__/TopBar.test.tsx
+++ b/packages/editor/src/components/__tests__/TopBar.test.tsx
@@ -121,7 +121,6 @@ describe('TopBar', () => {
 
             // Toggle buttons
             expect(screen.getByText('Hide Past: OFF')).toBeInTheDocument();
-            expect(screen.getByText('Auto Scroll: ON')).toBeInTheDocument();
 
             // Action buttons
             expect(screen.getByTitle('Copy Markdown')).toBeInTheDocument();
@@ -229,28 +228,7 @@ describe('TopBar', () => {
         });
     });
 
-    describe('Auto scroll', () => {
-        it('shows ON when autoScroll is true', () => {
-            render(<TopBar {...mockProps} />);
-            expect(screen.getByText('Auto Scroll: ON')).toBeInTheDocument();
-        });
-
-        it('shows OFF when autoScroll is false', () => {
-            render(<TopBar {...mockProps} topbar={{ ...mockProps.topbar, autoScroll: false }} />);
-            expect(screen.getByText('Auto Scroll: OFF')).toBeInTheDocument();
-        });
-
-        it('toggles autoScroll on click', () => {
-            render(<TopBar {...mockProps} />);
-
-            const button = screen.getByTitle('Disable auto scroll');
-            fireEvent.click(button);
-
-            expect(mockProps.onTopbarChange).toHaveBeenCalledWith({
-                autoScroll: false,
-            });
-        });
-    });
+    // Auto scroll toggle moved to PreviewPane header; no longer tested here
 
     describe('Actions', () => {
         it('clicks Copy Markdown button', () => {
@@ -288,7 +266,7 @@ describe('TopBar', () => {
             expect(screen.getByLabelText('Copy Markdown')).toBeInTheDocument();
             expect(screen.getByLabelText('Share via URL')).toBeInTheDocument();
             expect(screen.getByLabelText('Hide past days')).toBeInTheDocument();
-            expect(screen.getByLabelText('Disable auto scroll')).toBeInTheDocument();
+            // Auto scroll control not present in TopBar anymore
         });
 
         it('timezone select has the correct ID', () => {

--- a/packages/editor/src/components/__tests__/TopBar.test.tsx
+++ b/packages/editor/src/components/__tests__/TopBar.test.tsx
@@ -12,8 +12,8 @@ vi.mock('@radix-ui/react-dropdown-menu', () => ({
     },
     Portal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    Item: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
-        <button type="button" onClick={onClick}>
+    Item: ({ children, onSelect }: { children: React.ReactNode; onSelect?: () => void }) => (
+        <button type="button" onClick={onSelect}>
             {children}
         </button>
     ),

--- a/packages/editor/src/components/__tests__/TopBar.test.tsx
+++ b/packages/editor/src/components/__tests__/TopBar.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@radix-ui/react-dropdown-menu', () => ({
         </button>
     ),
     ItemIndicator: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+    Separator: () => <div />,
 }));
 
 vi.mock('@radix-ui/react-select', () => ({

--- a/packages/editor/src/components/dialog/ClearAllDialog.tsx
+++ b/packages/editor/src/components/dialog/ClearAllDialog.tsx
@@ -1,5 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import type React from 'react';
+import { useI18n } from '../../i18n';
 
 interface ClearAllDialogProps {
     open: boolean;
@@ -8,21 +9,22 @@ interface ClearAllDialogProps {
 }
 
 export const ClearAllDialog: React.FC<ClearAllDialogProps> = ({ open, onCancel, onClear }) => {
+    const { t } = useI18n();
     return (
         <Dialog.Root open={open}>
             <Dialog.Portal>
                 <Dialog.Overlay className="fixed inset-0 bg-black/40 z-50" />
                 <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg max-w-lg w-[90vw] p-6 z-50" onEscapeKeyDown={() => onCancel()} onPointerDownOutside={() => onCancel()}>
-                    <Dialog.Title className="text-lg font-semibold mb-3">Clear All Contents?</Dialog.Title>
-                    <Dialog.Description className="text-sm text-gray-600 mb-4">This will remove all editor contents and cannot be undone. Select "Clear" to proceed.</Dialog.Description>
+                    <Dialog.Title className="text-lg font-semibold mb-3">{t('dialog.clearAll.title')}</Dialog.Title>
+                    <Dialog.Description className="text-sm text-gray-600 mb-4">{t('dialog.clearAll.desc')}</Dialog.Description>
                     <div className="flex justify-end gap-2">
                         <Dialog.Close asChild>
                             <button type="button" className="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-700 hover:bg-gray-50" onClick={onCancel}>
-                                Cancel
+                                {t('dialog.clearAll.cancel')}
                             </button>
                         </Dialog.Close>
                         <button type="button" className="px-3 py-1.5 text-sm rounded bg-red-600 text-white hover:bg-red-700" onClick={onClear}>
-                            Clear
+                            {t('dialog.clearAll.clear')}
                         </button>
                     </div>
                 </Dialog.Content>

--- a/packages/editor/src/components/dialog/LoadSampleDialog.tsx
+++ b/packages/editor/src/components/dialog/LoadSampleDialog.tsx
@@ -1,5 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import type React from 'react';
+import { useI18n } from '../../i18n';
 
 interface LoadSampleDialogProps {
     open: boolean;
@@ -8,21 +9,22 @@ interface LoadSampleDialogProps {
 }
 
 export const LoadSampleDialog: React.FC<LoadSampleDialogProps> = ({ open, onCancel, onLoad }) => {
+    const { t } = useI18n();
     return (
         <Dialog.Root open={open} onOpenChange={(o) => !o && onCancel()}>
             <Dialog.Portal>
                 <Dialog.Overlay className="fixed inset-0 bg-black/40 z-50" />
                 <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg max-w-lg w-[90vw] p-6 z-50">
-                    <Dialog.Title className="text-lg font-semibold mb-3">Load Sample Itinerary?</Dialog.Title>
-                    <Dialog.Description className="text-sm text-gray-600 mb-4">This will replace your current content with the sample itinerary. Select "Load" to proceed.</Dialog.Description>
+                    <Dialog.Title className="text-lg font-semibold mb-3">{t('dialog.loadSample.title')}</Dialog.Title>
+                    <Dialog.Description className="text-sm text-gray-600 mb-4">{t('dialog.loadSample.desc')}</Dialog.Description>
                     <div className="flex justify-end gap-2">
                         <Dialog.Close asChild>
                             <button type="button" className="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-700 hover:bg-gray-50">
-                                Cancel
+                                {t('dialog.loadSample.cancel')}
                             </button>
                         </Dialog.Close>
                         <button type="button" className="px-3 py-1.5 text-sm rounded bg-blue-600 text-white hover:bg-blue-700" onClick={onLoad}>
-                            Load
+                            {t('dialog.loadSample.load')}
                         </button>
                     </div>
                 </Dialog.Content>

--- a/packages/editor/src/components/editor/EditorPane.tsx
+++ b/packages/editor/src/components/editor/EditorPane.tsx
@@ -10,7 +10,7 @@ export const EditorPane: React.FC<{
 }> = ({ value, onChange, onSave, onCursorLineChange, className = '' }) => {
     return (
         <div className={`h-full min-h-0 flex flex-col ${className}`}>
-            <div className="px-2 py-1 bg-gray-100 border-b border-gray-300 font-medium text-sm text-gray-600">Editor</div>
+            <div className="h-8 px-2 py-1 flex items-center bg-gray-100 border-b border-gray-300 font-medium text-sm text-gray-600">Editor</div>
             <div className="h-[calc(100%-41px)] min-h-0">
                 <MonacoEditor value={value} onChange={onChange} onSave={onSave} onCursorLineChange={onCursorLineChange} />
             </div>

--- a/packages/editor/src/components/editor/EditorPane.tsx
+++ b/packages/editor/src/components/editor/EditorPane.tsx
@@ -11,7 +11,7 @@ export const EditorPane: React.FC<{
     return (
         <div className={`h-full min-h-0 flex flex-col ${className}`}>
             <div className="h-8 px-2 py-1 flex items-center bg-gray-100 border-b border-gray-300 font-medium text-sm text-gray-600">Editor</div>
-            <div className="h-[calc(100%-41px)] min-h-0">
+            <div className="flex-1 min-h-0">
                 <MonacoEditor value={value} onChange={onChange} onSave={onSave} onCursorLineChange={onCursorLineChange} />
             </div>
         </div>

--- a/packages/editor/src/components/editor/PreviewPane.tsx
+++ b/packages/editor/src/components/editor/PreviewPane.tsx
@@ -1,11 +1,14 @@
-import { Bug } from 'lucide-react';
+import * as Toggle from '@radix-ui/react-toggle';
+import { Bug, ChevronsDown } from 'lucide-react';
 import type React from 'react';
 import { MarkdownPreview } from '@/components/MarkdownPreview';
 import { MdastView } from '@/components/MdastView';
+import { useI18n } from '@/i18n';
 
 export const PreviewPane: React.FC<{
     showMdast: boolean;
     toggleMdast: () => void;
+    toggleAutoScroll: () => void;
     previewContent: string;
     frontmatterTitle?: string;
     frontmatterDescription?: string;
@@ -19,14 +22,50 @@ export const PreviewPane: React.FC<{
     showPast?: boolean;
     onShowPast?: () => void;
     preferAltNames?: boolean;
-}> = ({ showMdast, toggleMdast, previewContent, frontmatterTitle, frontmatterDescription, frontmatterTags, timezone, currency, rate, activeLine, autoScroll, className = '', showPast, onShowPast, preferAltNames }) => {
+    externalContainerRef?: React.MutableRefObject<HTMLDivElement | null>;
+}> = ({
+    showMdast,
+    toggleMdast,
+    toggleAutoScroll,
+    previewContent,
+    frontmatterTitle,
+    frontmatterDescription,
+    frontmatterTags,
+    timezone,
+    currency,
+    rate,
+    activeLine,
+    autoScroll,
+    className = '',
+    showPast,
+    onShowPast,
+    preferAltNames,
+    externalContainerRef,
+}) => {
+    const { t } = useI18n();
     return (
-        <div className={`h-full min-h-0 flex flex-col ${className}`}>
-            <div className="px-2 py-1 flex justify-between bg-gray-100 border-b border-gray-300 font-medium text-sm text-gray-600 group">
+        <div className={`h-full min-h-0 flex flex-col group ${className}`}>
+            <div className="h-8 px-2 py-1 flex items-center justify-between bg-gray-100 border-b border-gray-300 font-medium text-sm text-gray-600 group/debug">
                 <span>{showMdast ? 'MDAST' : 'Preview'}</span>
-                <button type="button" className="text-sm text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity" onClick={toggleMdast}>
-                    <Bug size={12} />
-                </button>
+                <div className="flex items-center gap-1">
+                    <Toggle.Root
+                        pressed={!!showMdast}
+                        onPressedChange={toggleMdast}
+                        className={`transition-opacity text-sm opacity-0 group-hover/debug:opacity-100 inline-flex items-center justify-center px-1.5 h-6 ${showMdast ? 'opacity-100 text-red-700' : 'text-gray-600'}`}
+                    >
+                        <Bug size={12} />
+                    </Toggle.Root>
+                    <Toggle.Root
+                        pressed={!!autoScroll}
+                        onPressedChange={toggleAutoScroll}
+                        aria-label={!autoScroll ? t('autoScroll.enable') : t('autoScroll.disable')}
+                        title={!autoScroll ? t('autoScroll.enable') : t('autoScroll.disable')}
+                        className={`text-sm opacity-0 group-hover:opacity-100 transition-opacity inline-flex items-center justify-center px-1.5 h-6 rounded border ${autoScroll ? 'text-white bg-gray-700 border-gray-700' : 'text-gray-600 border-gray-300 bg-white hover:bg-gray-50'} ${showMdast ? 'opacity-100' : ''}`}
+                    >
+                        <ChevronsDown size={12} />
+                        <span className="hidden md:inline text-xs ml-1">{t('autoScroll.label', { state: autoScroll ? t('past.on') : t('past.off') })}</span>
+                    </Toggle.Root>
+                </div>
             </div>
             <div className="h-[calc(100%-41px)] min-h-0">
                 {showMdast ? (
@@ -45,6 +84,7 @@ export const PreviewPane: React.FC<{
                         showPast={showPast}
                         onShowPast={onShowPast}
                         preferAltNames={preferAltNames}
+                        externalContainerRef={externalContainerRef}
                     />
                 )}
             </div>

--- a/packages/editor/src/components/editor/PreviewPane.tsx
+++ b/packages/editor/src/components/editor/PreviewPane.tsx
@@ -49,6 +49,8 @@ export const PreviewPane: React.FC<{
                 <span>{showMdast ? 'MDAST' : 'Preview'}</span>
                 <div className="flex items-center gap-1">
                     <Toggle.Root
+                        aria-label="Toggle MDAST view"
+                        title="Toggle MDAST view"
                         pressed={!!showMdast}
                         onPressedChange={toggleMdast}
                         className={`transition-opacity text-sm opacity-0 group-hover/debug:opacity-100 inline-flex items-center justify-center px-1.5 h-6 ${showMdast ? 'opacity-100 text-red-700' : 'text-gray-600'}`}

--- a/packages/editor/src/components/itinerary/AirlineLogo.tsx
+++ b/packages/editor/src/components/itinerary/AirlineLogo.tsx
@@ -46,6 +46,7 @@ export const AirlineLogo: React.FC<AirlineLogoProps> = ({ flightCode, size = 24,
                     title={`${airlineCode} logo`}
                     style={{
                         height: '100%',
+                        maxWidth: '180px',
                         width: 'auto',
                         objectFit: 'contain',
                     }}

--- a/packages/editor/src/components/itinerary/AirlineLogo.tsx
+++ b/packages/editor/src/components/itinerary/AirlineLogo.tsx
@@ -27,17 +27,15 @@ export const AirlineLogo: React.FC<AirlineLogoProps> = ({ flightCode, size = 24,
         return fallbackIcon ? <Plane size={size} style={{ color: '#6b7280' }} /> : null;
     }
 
-    const logoUrl = `https://img.wway.io/pics/root/${airlineCode.toUpperCase()}@png?exar=1&rs=fit:${size}:${size}`;
+    const logoUrl = `https://img.wway.io/pics/root/${airlineCode.toUpperCase()}@png?exar=1&h=${size * 2}`;
 
     return (
         <div
             style={{
-                width: size,
                 height: size,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                borderRadius: '4px',
                 overflow: 'hidden',
             }}
         >
@@ -47,8 +45,8 @@ export const AirlineLogo: React.FC<AirlineLogoProps> = ({ flightCode, size = 24,
                     alt={`${airlineCode} logo`}
                     title={`${airlineCode} logo`}
                     style={{
-                        maxWidth: '100%',
-                        maxHeight: '100%',
+                        height: '100%',
+                        width: 'auto',
                         objectFit: 'contain',
                     }}
                     onError={() => setHasError(true)}

--- a/packages/editor/src/components/itinerary/EventBlock.tsx
+++ b/packages/editor/src/components/itinerary/EventBlock.tsx
@@ -235,7 +235,7 @@ export const EventBlock: React.FC<EventBlockProps> = ({ eventData, dateStr, time
     })();
 
     return (
-        <div className="my-3 flex items-center">
+        <div className="my-3 flex items-center break-inside-avoid">
             {!startISO && !endISO && !marker ? (
                 <TimePlaceholder />
             ) : (

--- a/packages/editor/src/components/itinerary/EventBlock.tsx
+++ b/packages/editor/src/components/itinerary/EventBlock.tsx
@@ -1,10 +1,9 @@
-//
-
 import { AirlineLogo } from '@/components/itinerary/AirlineLogo';
+import { EventBodySegments } from '@/components/itinerary/EventBodySegments';
 import { Location } from '@/components/itinerary/Location';
 import { Route } from '@/components/itinerary/Route';
 import { SegmentedText } from '@/components/itinerary/SegmentedText';
-import { formatDateTime, getDayOffset } from '@/utils/timezone';
+import { TimeDisplay } from '@/components/itinerary/TimeDisplay';
 import { isAllowedHref } from '@/utils/url';
 
 interface EventBlockProps {
@@ -39,20 +38,18 @@ interface EventBlockProps {
             | 'park'
             | 'cafe';
         name?: string;
-        stayName?: string;
-        departure?: string;
-        arrival?: string;
-        location?: string;
+        destination?:
+            | { kind: 'fromTo'; from: Array<{ text: string; url?: string }>; to: Array<{ text: string; url?: string }> }
+            | { kind: 'dashPair'; from: Array<{ text: string; url?: string }>; to: Array<{ text: string; url?: string }> }
+            | { kind: 'single'; at: Array<{ text: string; url?: string }> };
         metadata: Record<string, string>;
     };
     dateStr?: string;
     timezone?: string;
     currency?: string;
     priceInfos?: Array<{ key: string; currency: string; amount: number }>;
-    extraLinks?: Array<{ label: string; url: string }>;
+    priceWarningsByKey?: Record<string, string[]>;
     nameSegments?: Array<{ text: string; url?: string }>;
-    departureSegments?: Array<{ text: string; url?: string }>;
-    arrivalSegments?: Array<{ text: string; url?: string }>;
     startISO?: string | null;
     endISO?: string | null;
     marker?: 'am' | 'pm' | null;
@@ -83,14 +80,12 @@ const getTypeColors = (type: EventBlockProps['eventData']['type'], baseType: Eve
     const key = String(type || 'activity');
     const [h] = colorHash.hsl(key);
 
-    // Static palette (keep Tailwind class names as string literals)
     const PALETTE: Record<
         string,
         {
             text: string;
             border: string;
             cardBg: string;
-            borderLeft: string;
             iconBg: string;
         }
     > = {
@@ -98,91 +93,78 @@ const getTypeColors = (type: EventBlockProps['eventData']['type'], baseType: Eve
             text: 'text-purple-600',
             border: 'border-purple-600',
             cardBg: 'bg-purple-50',
-            borderLeft: 'border-l-purple-600',
             iconBg: 'bg-purple-600',
         },
         red: {
             text: 'text-red-600',
             border: 'border-red-600',
             cardBg: 'bg-red-50',
-            borderLeft: 'border-l-red-600',
             iconBg: 'bg-red-600',
         },
         orange: {
             text: 'text-orange-600',
             border: 'border-orange-600',
             cardBg: 'bg-orange-50',
-            borderLeft: 'border-l-orange-600',
             iconBg: 'bg-orange-600',
         },
         amber: {
             text: 'text-amber-600',
             border: 'border-amber-600',
             cardBg: 'bg-amber-50',
-            borderLeft: 'border-l-amber-600',
             iconBg: 'bg-amber-600',
         },
         yellow: {
             text: 'text-yellow-600',
             border: 'border-yellow-600',
             cardBg: 'bg-yellow-50',
-            borderLeft: 'border-l-yellow-600',
             iconBg: 'bg-yellow-600',
         },
         lime: {
             text: 'text-lime-600',
             border: 'border-lime-600',
             cardBg: 'bg-lime-50',
-            borderLeft: 'border-l-lime-600',
             iconBg: 'bg-lime-600',
         },
         green: {
             text: 'text-green-600',
             border: 'border-green-600',
             cardBg: 'bg-green-50',
-            borderLeft: 'border-l-green-600',
             iconBg: 'bg-green-600',
         },
         emerald: {
             text: 'text-emerald-600',
             border: 'border-emerald-600',
             cardBg: 'bg-emerald-50',
-            borderLeft: 'border-l-emerald-600',
             iconBg: 'bg-emerald-600',
         },
         teal: {
             text: 'text-teal-600',
             border: 'border-teal-600',
             cardBg: 'bg-teal-50',
-            borderLeft: 'border-l-teal-600',
             iconBg: 'bg-teal-600',
         },
         cyan: {
             text: 'text-cyan-600',
             border: 'border-cyan-600',
             cardBg: 'bg-cyan-50',
-            borderLeft: 'border-l-cyan-600',
             iconBg: 'bg-cyan-600',
         },
         blue: {
             text: 'text-blue-600',
             border: 'border-blue-600',
             cardBg: 'bg-blue-50',
-            borderLeft: 'border-l-blue-600',
             iconBg: 'bg-blue-600',
         },
         pink: {
             text: 'text-pink-600',
             border: 'border-pink-600',
             cardBg: 'bg-pink-50',
-            borderLeft: 'border-l-pink-600',
             iconBg: 'bg-pink-600',
         },
         gray: {
             text: 'text-gray-600',
             border: 'border-gray-600',
             cardBg: 'bg-gray-50',
-            borderLeft: 'border-l-gray-600',
             iconBg: 'bg-gray-600',
         },
     };
@@ -213,55 +195,10 @@ import { TimePlaceholder } from '@/components/itinerary/TimePlaceholder';
 
 const getTypeIcon = (type: EventBlockProps['eventData']['type']) => getIconForEventType(type);
 
-const TimeDisplay: React.FC<{
-    iso?: string | null;
-    marker?: 'am' | 'pm' | null;
-    dateStr?: string;
-    timezone?: string;
-}> = ({ iso, marker, dateStr, timezone }) => {
-    if (!iso && !marker) {
-        return <span className="font-mono text-lg leading-tight relative inline-block invisible">-----</span>;
-    }
-
-    if (marker) {
-        const label = marker === 'am' ? 'AM' : 'PM';
-        return <span className="font-mono text-lg leading-tight inline-block whitespace-pre">{label.padStart(5, ' ')}</span>;
-    }
-
-    const displayTz = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const date = iso ? new Date(iso) : undefined;
-    if (!date || Number.isNaN(date.getTime())) {
-        return <span className="font-mono text-lg leading-tight relative inline-block invisible">-----</span>;
-    }
-    const timeText = formatDateTime(date, displayTz);
-
-    const dayOffset = dateStr && displayTz ? getDayOffset(date, dateStr, displayTz) : 0;
-    const plusBadge = dayOffset !== 0 ? `${dayOffset > 0 ? '+' : ''}${dayOffset}d` : '';
-
-    return (
-        <span className="font-mono text-lg text-gray-800 leading-tight relative inline-block">
-            {timeText}
-            {plusBadge && <span className="absolute -bottom-3 -right-0 text-xs font-bold text-white bg-red-500 rounded px-0.5 ">{plusBadge}</span>}
-        </span>
-    );
-};
-
-import { Meta } from '@/components/itinerary/Metadata';
-
-export const EventBlock: React.FC<EventBlockProps> = ({ eventData, dateStr, timezone, currency, priceInfos, extraLinks, nameSegments, departureSegments, arrivalSegments, startISO, endISO, marker, bodySegments }) => {
+export const EventBlock: React.FC<EventBlockProps> = ({ eventData, dateStr, timezone, currency, priceWarningsByKey, priceInfos, nameSegments, startISO, endISO, marker, bodySegments }) => {
     const colors = getTypeColors(eventData.type, eventData.baseType);
     const IconComponent = getTypeIcon(eventData.type);
-    const mainTitle = (() => {
-        switch (eventData.baseType) {
-            case 'transportation':
-            case 'activity':
-                return eventData.name;
-            case 'stay':
-                return eventData.stayName;
-            default:
-                return '';
-        }
-    })();
+    const mainTitle = eventData.name;
 
     const displayTitle = (() => {
         if (mainTitle && String(mainTitle).trim() !== '') return String(mainTitle);
@@ -269,14 +206,32 @@ export const EventBlock: React.FC<EventBlockProps> = ({ eventData, dateStr, time
     })();
 
     const routeOrLocationDisplay = (() => {
-        if (eventData.baseType === 'transportation' && eventData.departure && eventData.arrival) {
-            const meta = eventData.metadata as Record<string, string>;
-            return <Route departure={eventData.departure} arrival={eventData.arrival} departureUrl={meta.departure__url} arrivalUrl={meta.arrival__url} departureSegments={departureSegments} arrivalSegments={arrivalSegments} />;
+        const dest = eventData.destination as
+            | { kind: 'fromTo'; from: Array<{ text: string; url?: string }>; to: Array<{ text: string; url?: string }> }
+            | { kind: 'dashPair'; from: Array<{ text: string; url?: string }>; to: Array<{ text: string; url?: string }> }
+            | { kind: 'single'; at: Array<{ text: string; url?: string }> }
+            | undefined;
+        if (!dest) return null;
+        if (dest.kind === 'fromTo' || dest.kind === 'dashPair') {
+            const hasFrom = Array.isArray(dest.from) && dest.from.length > 0;
+            const hasTo = Array.isArray(dest.to) && dest.to.length > 0;
+            if (hasFrom && hasTo) return <Route departureSegments={dest.from} arrivalSegments={dest.to} />;
+            const single = hasFrom ? dest.from : hasTo ? dest.to : [];
+            return single.length > 0 ? <Location location={undefined as unknown as string} segments={single} /> : null;
         }
-        if ((eventData.baseType === 'stay' || eventData.baseType === 'activity') && eventData.location) {
-            return <Location location={eventData.location} segments={arrivalSegments} />;
+        if (dest.kind === 'single') {
+            return Array.isArray(dest.at) && dest.at.length > 0 ? <Location location={undefined as unknown as string} segments={dest.at} /> : null;
         }
         return null;
+    })();
+
+    const titleSegments = (() => {
+        if (Array.isArray(nameSegments) && nameSegments.length > 0) return nameSegments;
+        const titleText = displayTitle;
+        if (!titleText) return undefined;
+        const meta = eventData.metadata as Record<string, string>;
+        const url = meta.name__url;
+        return url && isAllowedHref(url) ? [{ text: titleText, url }] : [{ text: titleText }];
     })();
 
     return (
@@ -296,124 +251,13 @@ export const EventBlock: React.FC<EventBlockProps> = ({ eventData, dateStr, time
                 </div>
             </div>
 
-            <div className={`flex-1 min-w-0 p-5 -ml-4.5 pl-8 ${colors.cardBg} border-l-4 ${colors.borderLeft}`}>
-                <div className="flex items-center gap-x-3 flex-wrap">
+            <div className={`flex-1 min-w-0 p-5 -ml-4.5 pl-8 ${colors.cardBg} border-l-4 ${colors.border}`}>
+                <div className="flex items-center gap-x-3 gap-y-1 flex-wrap">
                     {eventData.type === 'flight' && 'name' in eventData && eventData.name && <AirlineLogo flightCode={eventData.name} size={24} />}
-                    {(() => {
-                        const segments =
-                            nameSegments ||
-                            (() => {
-                                const titleText = displayTitle;
-                                if (!titleText) return undefined;
-                                const meta = eventData.metadata as Record<string, string>;
-                                const url = meta.name__url;
-                                if (url && isAllowedHref(url)) {
-                                    return [{ text: titleText, url }];
-                                }
-                                return [{ text: titleText }];
-                            })();
-
-                        if (segments) {
-                            return <SegmentedText segments={segments} className={`font-bold ${colors.text} text-lg`} linkClassName="underline text-inherit" />;
-                        }
-                        return null;
-                    })()}
+                    {titleSegments ? <SegmentedText segments={titleSegments} className={`font-bold ${colors.text} text-lg`} linkClassName="underline text-inherit" /> : null}
                     {routeOrLocationDisplay && <div className="text-gray-700 text-sm font-medium">{routeOrLocationDisplay}</div>}
-                    {Array.isArray(extraLinks) && extraLinks.length > 0 && (
-                        <div className="flex items-center gap-2 text-sm">
-                            {extraLinks
-                                .filter((l) => l && typeof l.url === 'string' && isAllowedHref(l.url))
-                                .map((l, idx) => (
-                                    <a key={`${l.label}-${idx}`} href={l.url} target="_blank" rel="noopener noreferrer" className="underline">
-                                        {l.label}
-                                    </a>
-                                ))}
-                        </div>
-                    )}
                 </div>
-                {Array.isArray(bodySegments) && bodySegments.length > 0 ? (
-                    <div className={`mt-2 pt-2 border-t ${colors.border}`}>
-                        {bodySegments.map((seg, idx) => {
-                            if (!seg) return null;
-                            if ((seg as { kind?: string }).kind === 'inline') {
-                                const s = seg as {
-                                    kind: 'inline';
-                                    segments: Array<{ text: string; url?: string }>;
-                                };
-                                if (!Array.isArray(s.segments) || s.segments.length === 0) return null;
-                                const key = `inline-${s.segments
-                                    .map((x) => `${x.text}-${x.url ?? ''}`)
-                                    .join('|')
-                                    .slice(0, 64)}-${idx}`;
-                                return <SegmentedText key={key} segments={s.segments} className="block text-gray-700 text-sm mb-1" linkClassName="underline text-inherit" />;
-                            }
-                            if ((seg as { kind?: string }).kind === 'meta') {
-                                const m = seg as {
-                                    kind: 'meta';
-                                    entries: Array<{
-                                        key: string;
-                                        segments: Array<{ text: string; url?: string }>;
-                                    }>;
-                                };
-                                const key = `meta-${m.entries
-                                    .map((e) => e.key)
-                                    .join('|')
-                                    .slice(0, 64)}-${idx}`;
-                                return <Meta key={key} entries={m.entries} metadata={{}} borderColor={colors.border} currency={currency} priceInfos={priceInfos} />;
-                            }
-                            if ((seg as { kind?: string }).kind === 'list') {
-                                const l = seg as {
-                                    kind: 'list';
-                                    items: Array<Array<{ text: string; url?: string }>>;
-                                    ordered?: boolean;
-                                    start?: number | null;
-                                };
-                                if (!Array.isArray(l.items) || l.items.length === 0) return null;
-                                const isOrdered = !!l.ordered;
-                                const start = typeof l.start === 'number' ? l.start : undefined;
-                                if (isOrdered) {
-                                    return (
-                                        <ol key={`list-${start ?? 'ol'}`} className="ml-6 list-decimal marker:text-blue-600 marker:font-bold marker:text-base" start={start}>
-                                            {l.items.map((it) => {
-                                                const keyStr = it
-                                                    .map((seg) => `${seg.text}-${seg.url ?? ''}`)
-                                                    .join('|')
-                                                    .slice(0, 64);
-                                                return (
-                                                    <li key={`li-${keyStr}`}>
-                                                        <SegmentedText segments={it} className="text-gray-700 text-sm" linkClassName="underline text-inherit" />
-                                                    </li>
-                                                );
-                                            })}
-                                        </ol>
-                                    );
-                                }
-                                return (
-                                    <ul
-                                        key={`list-ul-${l.items.length}-${(l.items[0] || [])
-                                            .map((x) => x.text)
-                                            .join('-')
-                                            .slice(0, 16)}`}
-                                        className="ml-6 list-disc marker:text-blue-600 marker:font-bold marker:text-base"
-                                    >
-                                        {l.items.map((it) => {
-                                            const keyStr = it
-                                                .map((seg) => `${seg.text}-${seg.url ?? ''}`)
-                                                .join('|')
-                                                .slice(0, 64);
-                                            return (
-                                                <li key={`li-${keyStr}`}>
-                                                    <SegmentedText segments={it} className="text-gray-700 text-sm" linkClassName="underline text-inherit" />
-                                                </li>
-                                            );
-                                        })}
-                                    </ul>
-                                );
-                            }
-                            return null;
-                        })}
-                    </div>
-                ) : null}
+                <EventBodySegments bodySegments={bodySegments} borderClass={colors.border} priceWarningsByKey={priceWarningsByKey} priceInfos={priceInfos} toCurrency={currency} />
             </div>
         </div>
     );

--- a/packages/editor/src/components/itinerary/EventBodySegments.tsx
+++ b/packages/editor/src/components/itinerary/EventBodySegments.tsx
@@ -1,0 +1,133 @@
+import type React from 'react';
+import { Meta } from '@/components/itinerary/Metadata';
+import { Price } from '@/components/itinerary/Price';
+import { SegmentedText } from '@/components/itinerary/SegmentedText';
+import { useRatesUSD } from '@/hooks/useRatesUSD';
+import { formatConvertedPreferred } from '@/utils/currency';
+
+export const EventBodySegments: React.FC<{
+    bodySegments?: Array<
+        | { kind: 'inline'; segments: Array<{ text: string; url?: string }> }
+        | { kind: 'meta'; entries: Array<{ key: string; segments: Array<{ text: string; url?: string }> }> }
+        | { kind: 'list'; items: Array<Array<{ text: string; url?: string }>>; ordered?: boolean; start?: number | null }
+    >;
+    borderClass: string;
+    priceWarningsByKey?: Record<string, string[]>;
+    priceInfos?: Array<{ key: string; currency: string; amount: number }>;
+    toCurrency?: string;
+}> = ({ bodySegments, borderClass, priceWarningsByKey, priceInfos, toCurrency }) => {
+    const { data: ratesData } = useRatesUSD();
+    if (!Array.isArray(bodySegments) || bodySegments.length === 0) return null;
+    return (
+        <div className={`mt-2 pt-2 border-t ${borderClass}`}>
+            {bodySegments.map((seg, idx) => {
+                if (!seg) return null;
+                if ((seg as { kind?: string }).kind === 'inline') {
+                    const s = seg as { kind: 'inline'; segments: Array<{ text: string; url?: string }> };
+                    if (!Array.isArray(s.segments) || s.segments.length === 0) return null;
+                    const key = `inline-${s.segments
+                        .map((x) => `${x.text}-${x.url ?? ''}`)
+                        .join('|')
+                        .slice(0, 64)}-${idx}`;
+                    return <SegmentedText key={key} segments={s.segments} className="block text-gray-700 text-sm mb-1" linkClassName="underline text-inherit" />;
+                }
+                if ((seg as { kind?: string }).kind === 'meta') {
+                    const m = seg as { kind: 'meta'; entries: Array<{ key: string; segments: Array<{ text: string; url?: string }> }> };
+                    const priceEntries = (m.entries || []).filter((e) => e && (e.key === 'price' || e.key === 'cost'));
+                    const restEntries = (m.entries || []).filter((e) => !e || (e.key !== 'price' && e.key !== 'cost'));
+                    if (priceEntries.length > 0) {
+                        const infoByKey = (() => {
+                            const map: Record<string, { currency: string; amount: number }> = {};
+                            for (const p of priceInfos || []) {
+                                const k = String(p.key || '').toLowerCase();
+                                if (!k) continue;
+                                map[k] = { currency: p.currency, amount: p.amount };
+                            }
+                            return map;
+                        })();
+                        const metaKeyStable = `meta-${priceEntries
+                            .map((e) => e.key)
+                            .join('|')
+                            .slice(0, 64)}-${restEntries
+                            .map((e) => e.key)
+                            .join('|')
+                            .slice(0, 64)}`;
+                        return (
+                            <div key={metaKeyStable} className="flex flex-wrap gap-x-2">
+                                {priceEntries.map((e) => {
+                                    const kind = (e.key === 'price' ? 'price' : 'cost') as 'price' | 'cost';
+                                    const warns = priceWarningsByKey?.[kind];
+                                    const segKey = `${kind}-${e.segments
+                                        .map((s) => `${s.text}-${s.url ?? ''}`)
+                                        .join('|')
+                                        .slice(0, 64)}`;
+                                    const info = infoByKey[String(kind)];
+                                    let display = undefined as string | undefined;
+                                    if (info) {
+                                        const from = String(info.currency || '').toUpperCase();
+                                        const to = String(toCurrency || '').toUpperCase();
+                                        display = formatConvertedPreferred(info.amount, from, to, ratesData?.rates);
+                                    }
+                                    return <Price key={segKey} kind={kind} segments={e.segments} warnings={warns} display={display} />;
+                                })}
+                                {restEntries.length > 0 ? <Meta entries={restEntries} metadata={{}} /> : null}
+                            </div>
+                        );
+                    }
+                    const key = `meta-${restEntries
+                        .map((e) => e.key)
+                        .join('|')
+                        .slice(0, 64)}-${idx}`;
+                    return <Meta key={key} entries={restEntries} metadata={{}} />;
+                }
+                if ((seg as { kind?: string }).kind === 'list') {
+                    const l = seg as { kind: 'list'; items: Array<Array<{ text: string; url?: string }>>; ordered?: boolean; start?: number | null };
+                    if (!Array.isArray(l.items) || l.items.length === 0) return null;
+                    const isOrdered = !!l.ordered;
+                    const start = typeof l.start === 'number' ? l.start : undefined;
+                    if (isOrdered) {
+                        return (
+                            <ol key={`list-${start ?? 'ol'}`} className="ml-6 list-decimal marker:text-blue-600 marker:font-bold marker:text-base" start={start}>
+                                {l.items.map((it) => {
+                                    const keyStr = it
+                                        .map((seg) => `${seg.text}-${seg.url ?? ''}`)
+                                        .join('|')
+                                        .slice(0, 64);
+                                    return (
+                                        <li key={`li-${keyStr}`}>
+                                            <SegmentedText segments={it} className="text-gray-700 text-sm" linkClassName="underline text-inherit" />
+                                        </li>
+                                    );
+                                })}
+                            </ol>
+                        );
+                    }
+                    return (
+                        <ul
+                            key={`list-ul-${l.items.length}-${(l.items[0] || [])
+                                .map((x) => x.text)
+                                .join('-')
+                                .slice(0, 16)}`}
+                            className="ml-6 list-disc marker:text-blue-600 marker:font-bold marker:text-base"
+                        >
+                            {l.items.map((it) => {
+                                const keyStr = it
+                                    .map((seg) => `${seg.text}-${seg.url ?? ''}`)
+                                    .join('|')
+                                    .slice(0, 64);
+                                return (
+                                    <li key={`li-${keyStr}`}>
+                                        <SegmentedText segments={it} className="text-gray-700 text-sm" linkClassName="underline text-inherit" />
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    );
+                }
+                return null;
+            })}
+        </div>
+    );
+};
+
+export default EventBodySegments;

--- a/packages/editor/src/components/itinerary/EventBodySegments.tsx
+++ b/packages/editor/src/components/itinerary/EventBodySegments.tsx
@@ -5,6 +5,65 @@ import { SegmentedText } from '@/components/itinerary/SegmentedText';
 import { useRatesUSD } from '@/hooks/useRatesUSD';
 import { formatConvertedPreferred } from '@/utils/currency';
 
+type MetaEntry = { key: string; segments: Array<{ text: string; url?: string }> };
+
+const toInfoByKey = (priceInfos?: Array<{ key: string; currency: string; amount: number }>): Record<string, { currency: string; amount: number }> => {
+    const map: Record<string, { currency: string; amount: number }> = {};
+    for (const p of priceInfos || []) {
+        const k = String(p.key || '').toLowerCase();
+        if (!k) continue;
+        map[k] = { currency: p.currency, amount: p.amount };
+    }
+    return map;
+};
+
+const PriceList: React.FC<{
+    entries: MetaEntry[];
+    priceWarningsByKey?: Record<string, string[]>;
+    infoByKey: Record<string, { currency: string; amount: number }>;
+    toCurrency?: string;
+    rates?: Record<string, number>;
+}> = ({ entries, priceWarningsByKey, infoByKey, toCurrency, rates }) => {
+    return (
+        <>
+            {entries.map((e) => {
+                const kind = (e.key === 'price' ? 'price' : 'cost') as 'price' | 'cost';
+                const warns = priceWarningsByKey?.[kind];
+                const segKey = `${kind}-${e.segments
+                    .map((s) => `${s.text}-${s.url ?? ''}`)
+                    .join('|')
+                    .slice(0, 64)}`;
+                const info = infoByKey[String(kind)];
+                let display = undefined as string | undefined;
+                if (info) {
+                    const from = String(info.currency || '').toUpperCase();
+                    const to = String(toCurrency || '').toUpperCase();
+                    display = formatConvertedPreferred(info.amount, from, to, rates);
+                }
+                return <Price key={segKey} kind={kind} segments={e.segments} warnings={warns} display={display} />;
+            })}
+        </>
+    );
+};
+
+const MetaList: React.FC<{ entries: MetaEntry[]; className?: string }> = ({ entries }) => {
+    if (!entries || entries.length === 0) return null;
+    return (
+        <>
+            {entries.map((e) => (
+                <Meta
+                    key={`meta-${e.key}-${e.segments
+                        .map((s) => `${s.text}-${s.url ?? ''}`)
+                        .join('|')
+                        .slice(0, 64)}`}
+                    metaKey={e.key}
+                    segments={e.segments}
+                />
+            ))}
+        </>
+    );
+};
+
 export const EventBodySegments: React.FC<{
     bodySegments?: Array<
         | { kind: 'inline'; segments: Array<{ text: string; url?: string }> }
@@ -32,19 +91,11 @@ export const EventBodySegments: React.FC<{
                     return <SegmentedText key={key} segments={s.segments} className="block text-gray-700 text-sm mb-1" linkClassName="underline text-inherit" />;
                 }
                 if ((seg as { kind?: string }).kind === 'meta') {
-                    const m = seg as { kind: 'meta'; entries: Array<{ key: string; segments: Array<{ text: string; url?: string }> }> };
+                    const m = seg as { kind: 'meta'; entries: MetaEntry[] };
                     const priceEntries = (m.entries || []).filter((e) => e && (e.key === 'price' || e.key === 'cost'));
                     const restEntries = (m.entries || []).filter((e) => !e || (e.key !== 'price' && e.key !== 'cost'));
                     if (priceEntries.length > 0) {
-                        const infoByKey = (() => {
-                            const map: Record<string, { currency: string; amount: number }> = {};
-                            for (const p of priceInfos || []) {
-                                const k = String(p.key || '').toLowerCase();
-                                if (!k) continue;
-                                map[k] = { currency: p.currency, amount: p.amount };
-                            }
-                            return map;
-                        })();
+                        const infoByKey = toInfoByKey(priceInfos);
                         const metaKeyStable = `meta-${priceEntries
                             .map((e) => e.key)
                             .join('|')
@@ -54,23 +105,8 @@ export const EventBodySegments: React.FC<{
                             .slice(0, 64)}`;
                         return (
                             <div key={metaKeyStable} className="flex flex-wrap gap-x-2">
-                                {priceEntries.map((e) => {
-                                    const kind = (e.key === 'price' ? 'price' : 'cost') as 'price' | 'cost';
-                                    const warns = priceWarningsByKey?.[kind];
-                                    const segKey = `${kind}-${e.segments
-                                        .map((s) => `${s.text}-${s.url ?? ''}`)
-                                        .join('|')
-                                        .slice(0, 64)}`;
-                                    const info = infoByKey[String(kind)];
-                                    let display = undefined as string | undefined;
-                                    if (info) {
-                                        const from = String(info.currency || '').toUpperCase();
-                                        const to = String(toCurrency || '').toUpperCase();
-                                        display = formatConvertedPreferred(info.amount, from, to, ratesData?.rates);
-                                    }
-                                    return <Price key={segKey} kind={kind} segments={e.segments} warnings={warns} display={display} />;
-                                })}
-                                {restEntries.length > 0 ? <Meta entries={restEntries} metadata={{}} /> : null}
+                                <PriceList entries={priceEntries} priceWarningsByKey={priceWarningsByKey} infoByKey={infoByKey} toCurrency={toCurrency} rates={ratesData?.rates} />
+                                <MetaList entries={restEntries} />
                             </div>
                         );
                     }
@@ -78,7 +114,11 @@ export const EventBodySegments: React.FC<{
                         .map((e) => e.key)
                         .join('|')
                         .slice(0, 64)}-${idx}`;
-                    return <Meta key={key} entries={restEntries} metadata={{}} />;
+                    return (
+                        <div key={key} className="flex flex-wrap gap-x-2">
+                            <MetaList entries={restEntries} />
+                        </div>
+                    );
                 }
                 if ((seg as { kind?: string }).kind === 'list') {
                     const l = seg as { kind: 'list'; items: Array<Array<{ text: string; url?: string }>>; ordered?: boolean; start?: number | null };

--- a/packages/editor/src/components/itinerary/EventBodySegments.tsx
+++ b/packages/editor/src/components/itinerary/EventBodySegments.tsx
@@ -92,8 +92,8 @@ export const EventBodySegments: React.FC<{
                 }
                 if ((seg as { kind?: string }).kind === 'meta') {
                     const m = seg as { kind: 'meta'; entries: MetaEntry[] };
-                    const priceEntries = (m.entries || []).filter((e) => e && (e.key === 'price' || e.key === 'cost'));
-                    const restEntries = (m.entries || []).filter((e) => !e || (e.key !== 'price' && e.key !== 'cost'));
+                    const priceEntries = (m.entries || []).filter((e) => e != null && (e.key === 'price' || e.key === 'cost'));
+                    const restEntries = (m.entries || []).filter((e) => e != null && e.key !== 'price' && e.key !== 'cost');
                     if (priceEntries.length > 0) {
                         const infoByKey = toInfoByKey(priceInfos);
                         const metaKeyStable = `meta-${priceEntries

--- a/packages/editor/src/components/itinerary/EventBodySegments.tsx
+++ b/packages/editor/src/components/itinerary/EventBodySegments.tsx
@@ -79,7 +79,7 @@ export const EventBodySegments: React.FC<{
     if (!Array.isArray(bodySegments) || bodySegments.length === 0) return null;
     return (
         <div className={`mt-2 pt-2 border-t ${borderClass}`}>
-            {bodySegments.map((seg, idx) => {
+            {bodySegments.map((seg) => {
                 if (!seg) return null;
                 if ((seg as { kind?: string }).kind === 'inline') {
                     const s = seg as { kind: 'inline'; segments: Array<{ text: string; url?: string }> };
@@ -87,7 +87,7 @@ export const EventBodySegments: React.FC<{
                     const key = `inline-${s.segments
                         .map((x) => `${x.text}-${x.url ?? ''}`)
                         .join('|')
-                        .slice(0, 64)}-${idx}`;
+                        .slice(0, 64)}`;
                     return <SegmentedText key={key} segments={s.segments} className="block text-gray-700 text-sm mb-1" linkClassName="underline text-inherit" />;
                 }
                 if ((seg as { kind?: string }).kind === 'meta') {
@@ -113,7 +113,7 @@ export const EventBodySegments: React.FC<{
                     const key = `meta-${restEntries
                         .map((e) => e.key)
                         .join('|')
-                        .slice(0, 64)}-${idx}`;
+                        .slice(0, 64)}`;
                     return (
                         <div key={key} className="flex flex-wrap gap-x-2">
                             <MetaList entries={restEntries} />

--- a/packages/editor/src/components/itinerary/IconLabelText.tsx
+++ b/packages/editor/src/components/itinerary/IconLabelText.tsx
@@ -13,6 +13,7 @@ export type IconLabelTextProps = {
     labelClassName?: string;
     textClassName?: string;
     linkClassName?: string;
+    title?: string;
 };
 
 export const IconLabelText: React.FC<IconLabelTextProps> = ({
@@ -26,6 +27,7 @@ export const IconLabelText: React.FC<IconLabelTextProps> = ({
     labelClassName = 'font-medium',
     textClassName = 'ml-1',
     linkClassName = 'underline text-inherit',
+    title,
 }) => {
     return (
         <div className={className}>
@@ -36,7 +38,7 @@ export const IconLabelText: React.FC<IconLabelTextProps> = ({
                     {labelSuffix}
                 </span>
             ) : null}
-            <SegmentedText segments={segments} className={textClassName} linkClassName={linkClassName} />
+            <SegmentedText segments={segments} className={textClassName} linkClassName={linkClassName} title={title} />
         </div>
     );
 };

--- a/packages/editor/src/components/itinerary/Metadata.tsx
+++ b/packages/editor/src/components/itinerary/Metadata.tsx
@@ -3,41 +3,17 @@ import type React from 'react';
 import { IconLabelText } from '@/components/itinerary/IconLabelText';
 import { getMetadataConfig } from '@/components/itinerary/iconMaps';
 import type { TextSegment } from '@/components/itinerary/SegmentedText';
-import { isAllowedHref } from '@/utils/url';
 
 // getMetadataConfig is consumed from a shared module
 
-export const Meta: React.FC<{
-    metadata?: Record<string, string>;
-    entries?: Array<{ key: string; segments: TextSegment[] }>;
-}> = ({ metadata = {}, entries: entriesProp }) => {
-    const entries = entriesProp
-        ? entriesProp.map((e) => [e.key, e.segments.map((s) => s.text).join('')] as [string, string])
-        : Object.entries(metadata).filter(([key]) => !key.endsWith('__url') && !key.endsWith('__link_label') && !key.endsWith('__segments'));
+export type MetaProps = {
+    metaKey: string;
+    segments: TextSegment[];
+    className?: string;
+};
 
-    if (entries.length === 0) return null;
-    return (
-        <div className={`flex flex-wrap gap-x-2`}>
-            {entries.map(([key, value], idx) => {
-                const config = getMetadataConfig(key);
-                const IconComponent = config.icon;
-                const segments: TextSegment[] = (() => {
-                    if (Array.isArray(entriesProp)) {
-                        const found = entriesProp[idx];
-                        if (found && found.key === key) return found.segments;
-                    }
-                    const segmentsJson = metadata?.[`${key}__segments` as keyof typeof metadata] as unknown as string | undefined;
-                    if (segmentsJson) {
-                        try {
-                            return JSON.parse(segmentsJson);
-                        } catch {}
-                    }
-                    const maybeUrl = metadata?.[`${key}__url` as keyof typeof metadata] as unknown as string | undefined;
-                    if (maybeUrl && isAllowedHref(maybeUrl)) return [{ text: value, url: maybeUrl }];
-                    return [{ text: value }];
-                })();
-                return <IconLabelText key={key} icon={IconComponent} label={config.label} segments={segments} />;
-            })}
-        </div>
-    );
+export const Meta: React.FC<MetaProps> = ({ metaKey, segments, className }) => {
+    const config = getMetadataConfig(metaKey);
+    const IconComponent = config.icon;
+    return <IconLabelText icon={IconComponent} label={config.label} segments={segments} className={className} />;
 };

--- a/packages/editor/src/components/itinerary/Metadata.tsx
+++ b/packages/editor/src/components/itinerary/Metadata.tsx
@@ -1,11 +1,8 @@
 //
 import type React from 'react';
-import { useMemo } from 'react';
 import { IconLabelText } from '@/components/itinerary/IconLabelText';
 import { getMetadataConfig } from '@/components/itinerary/iconMaps';
 import type { TextSegment } from '@/components/itinerary/SegmentedText';
-import { useRatesUSD } from '@/hooks/useRatesUSD';
-import { convertAmountUSDBase, formatCurrency } from '@/utils/currency';
 import { isAllowedHref } from '@/utils/url';
 
 // getMetadataConfig is consumed from a shared module
@@ -13,45 +10,10 @@ import { isAllowedHref } from '@/utils/url';
 export const Meta: React.FC<{
     metadata?: Record<string, string>;
     entries?: Array<{ key: string; segments: TextSegment[] }>;
-    borderColor: string;
-    currency?: string;
-    priceInfos?: Array<{ key: string; currency: string; amount: number }>;
-}> = ({ metadata = {}, entries: entriesProp, currency, priceInfos }) => {
+}> = ({ metadata = {}, entries: entriesProp }) => {
     const entries = entriesProp
         ? entriesProp.map((e) => [e.key, e.segments.map((s) => s.text).join('')] as [string, string])
         : Object.entries(metadata).filter(([key]) => !key.endsWith('__url') && !key.endsWith('__link_label') && !key.endsWith('__segments'));
-    const { data: ratesData } = useRatesUSD();
-
-    const converted = useMemo(() => {
-        if (!currency || !Array.isArray(priceInfos) || priceInfos.length === 0) return null;
-        const rates = ratesData?.rates;
-        const to = currency;
-        const buildFor = (k: 'cost' | 'price'): string | undefined => {
-            const items = (priceInfos || []).filter((p) => p.key === k);
-            if (items.length === 0) return undefined;
-            let sum = 0;
-            for (const p of items) {
-                const from = p.currency || to;
-                if (!rates) {
-                    if (from === to) sum += p.amount;
-                    continue;
-                }
-                if (from === to) sum += p.amount;
-                else {
-                    const cv = convertAmountUSDBase(p.amount, from, to, rates);
-                    if (cv != null) sum += cv;
-                }
-            }
-            if (sum <= 0) return undefined;
-            const originals = items.map((p) => formatCurrency(p.amount, p.currency));
-            const anyConverted = Boolean(rates) && items.some((p) => (p.currency || to) !== to);
-            const base = formatCurrency(sum, to);
-            return anyConverted ? `${base} (${originals.join(' + ')})` : base;
-        };
-        const cost = buildFor('cost');
-        const price = buildFor('price');
-        return cost || price ? { cost, price } : null;
-    }, [currency, priceInfos, ratesData]);
 
     if (entries.length === 0) return null;
     return (
@@ -59,13 +21,6 @@ export const Meta: React.FC<{
             {entries.map(([key, value], idx) => {
                 const config = getMetadataConfig(key);
                 const IconComponent = config.icon;
-                if (config.isSpecial) {
-                    const display = key === 'cost' ? converted?.cost : key === 'price' ? converted?.price : undefined;
-                    if (!display) return null;
-                    return (
-                        <IconLabelText key={key} icon={IconComponent} label={undefined} segments={[{ text: display }]} className="text-emerald-600 text-sm font-bold flex items-center" iconSize={14} iconClassName="mr-1" textClassName="" />
-                    );
-                }
                 const segments: TextSegment[] = (() => {
                     if (Array.isArray(entriesProp)) {
                         const found = entriesProp[idx];

--- a/packages/editor/src/components/itinerary/Price.tsx
+++ b/packages/editor/src/components/itinerary/Price.tsx
@@ -1,0 +1,25 @@
+import type React from 'react';
+import { IconLabelText } from '@/components/itinerary/IconLabelText';
+import { getMetadataConfig } from '@/components/itinerary/iconMaps';
+import type { TextSegment } from '@/components/itinerary/SegmentedText';
+
+export const Price: React.FC<{
+    kind: 'price' | 'cost';
+    display?: string;
+    segments: TextSegment[];
+    warnings?: string[];
+}> = ({ kind, display, segments, warnings }) => {
+    const cfg = getMetadataConfig(kind);
+    const Icon = cfg.icon;
+    const hasError = Array.isArray(warnings) && warnings.length > 0;
+    const textClassName = hasError ? 'ml-1 underline decoration-wavy decoration-red-500 decoration-from-font underline-offset-2' : undefined;
+    const title = hasError ? warnings?.join(', ') : undefined;
+
+    if (display) {
+        return <IconLabelText icon={Icon} label={undefined} segments={[{ text: display }]} className="text-emerald-600 text-sm font-bold flex items-center" iconSize={14} iconClassName="mr-1" textClassName={textClassName} title={title} />;
+    }
+
+    return <IconLabelText icon={Icon} label={undefined} segments={segments} className="text-emerald-600 text-sm font-bold flex items-center" iconSize={14} iconClassName="mr-1" textClassName={textClassName} title={title} />;
+};
+
+export default Price;

--- a/packages/editor/src/components/itinerary/SegmentedText.tsx
+++ b/packages/editor/src/components/itinerary/SegmentedText.tsx
@@ -12,12 +12,17 @@ interface SegmentedTextProps {
     fallbackText?: string;
     className?: string;
     linkClassName?: string;
+    title?: string;
 }
 
-export const SegmentedText: React.FC<SegmentedTextProps> = ({ segments, fallbackText, className = '', linkClassName = 'underline text-inherit' }) => {
+export const SegmentedText: React.FC<SegmentedTextProps> = ({ segments, fallbackText, className = '', linkClassName = 'underline text-inherit', title }) => {
     if (!segments || segments.length === 0) {
         if (!fallbackText) return null;
-        return <span className={className}>{fallbackText}</span>;
+        return (
+            <span className={className} title={title}>
+                {fallbackText}
+            </span>
+        );
     }
 
     const nodes = segments.map((seg) => {
@@ -34,5 +39,9 @@ export const SegmentedText: React.FC<SegmentedTextProps> = ({ segments, fallback
         return { type: 'text', value: seg.text } as const;
     });
 
-    return <span className={className}>{renderInline(nodes as any[], { linkClassName })}</span>;
+    return (
+        <span className={className} title={title}>
+            {renderInline(nodes as any[], { linkClassName })}
+        </span>
+    );
 };

--- a/packages/editor/src/components/itinerary/Statistics.tsx
+++ b/packages/editor/src/components/itinerary/Statistics.tsx
@@ -237,9 +237,9 @@ export const Statistics: React.FC<StatisticsProps> = ({ root, frontmatter, curre
         <div className="flex flex-wrap justify-evenly py-4 rounded bg-gray-50 border border-gray-300">
             <div className="basis-1/2 p-4 rounded-lg flex flex-col items-center justify-center">
                 <div className="flex flex-wrap items-baseline font-bold break-all whitespace-pre" aria-live="polite">
-                    {totalFormatted && (
-                        <p className={`text-3xl ${budgetDisplay?.remaining !== undefined && budgetDisplay?.remaining !== null ? (budgetDisplay.remaining >= 0 ? 'text-emerald-600' : 'text-red-600') : 'text-gray-800'}`}>{totalFormatted}</p>
-                    )}
+                    <p className={`text-3xl ${budgetDisplay?.remaining !== undefined && budgetDisplay?.remaining !== null ? (budgetDisplay.remaining >= 0 ? 'text-emerald-600' : 'text-red-600') : 'text-gray-800'}`}>
+                        {totalFormatted ?? '—'}
+                    </p>
                     {budgetDisplay && (
                         <>
                             <p className="text-sm mx-2">/</p>

--- a/packages/editor/src/components/itinerary/TimeDisplay.tsx
+++ b/packages/editor/src/components/itinerary/TimeDisplay.tsx
@@ -1,0 +1,37 @@
+import type React from 'react';
+import { formatDateTime, getDayOffset } from '@/utils/timezone';
+
+export const TimeDisplay: React.FC<{
+    iso?: string | null;
+    marker?: 'am' | 'pm' | null;
+    dateStr?: string;
+    timezone?: string;
+}> = ({ iso, marker, dateStr, timezone }) => {
+    if (!iso && !marker) {
+        return <span className="font-mono text-lg leading-tight relative inline-block invisible">-----</span>;
+    }
+
+    if (marker) {
+        const label = marker === 'am' ? 'AM' : 'PM';
+        return <span className="font-mono text-lg leading-tight inline-block whitespace-pre">{label.padStart(5, ' ')}</span>;
+    }
+
+    const displayTz = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const date = iso ? new Date(iso) : undefined;
+    if (!date || Number.isNaN(date.getTime())) {
+        return <span className="font-mono text-lg leading-tight relative inline-block invisible">-----</span>;
+    }
+    const timeText = formatDateTime(date, displayTz);
+
+    const dayOffset = dateStr && displayTz ? getDayOffset(date, dateStr, displayTz) : 0;
+    const plusBadge = dayOffset !== 0 ? `${dayOffset > 0 ? '+' : ''}${dayOffset}d` : '';
+
+    return (
+        <span className="font-mono text-lg text-gray-800 leading-tight relative inline-block">
+            {timeText}
+            {plusBadge && <span className="absolute -bottom-3 -right-0 text-xs font-bold text-white bg-red-500 rounded px-0.5 ">{plusBadge}</span>}
+        </span>
+    );
+};
+
+export default TimeDisplay;

--- a/packages/editor/src/components/itinerary/TimeDisplay.tsx
+++ b/packages/editor/src/components/itinerary/TimeDisplay.tsx
@@ -16,7 +16,7 @@ export const TimeDisplay: React.FC<{
         return <span className="font-mono text-lg leading-tight inline-block whitespace-pre">{label.padStart(5, ' ')}</span>;
     }
 
-    const displayTz = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const displayTz = timezone || (typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'UTC');
     const date = iso ? new Date(iso) : undefined;
     if (!date || Number.isNaN(date.getTime())) {
         return <span className="font-mono text-lg leading-tight relative inline-block invisible">-----</span>;
@@ -29,7 +29,7 @@ export const TimeDisplay: React.FC<{
     return (
         <span className="font-mono text-lg text-gray-800 leading-tight relative inline-block">
             {timeText}
-            {plusBadge && <span className="absolute -bottom-3 -right-0 text-xs font-bold text-white bg-red-500 rounded px-0.5 ">{plusBadge}</span>}
+            {plusBadge && <span className="absolute -bottom-3 -right-0 text-xs font-bold text-white bg-red-500 rounded px-0.5">{plusBadge}</span>}
         </span>
     );
 };

--- a/packages/editor/src/i18n/en.json
+++ b/packages/editor/src/i18n/en.json
@@ -28,5 +28,13 @@
     "menu.clearAll": "Clear All Contents",
     "menu.language": "Language",
     "menu.language.en": "English",
-    "menu.language.ja": "Japanese"
+    "menu.language.ja": "Japanese",
+    "dialog.loadSample.title": "Load Sample Itinerary?",
+    "dialog.loadSample.desc": "This will replace your current content with the sample itinerary. Select \"Load\" to proceed.",
+    "dialog.loadSample.cancel": "Cancel",
+    "dialog.loadSample.load": "Load",
+    "dialog.clearAll.title": "Clear All Contents?",
+    "dialog.clearAll.desc": "This will remove all editor contents and cannot be undone. Select \"Clear\" to proceed.",
+    "dialog.clearAll.cancel": "Cancel",
+    "dialog.clearAll.clear": "Clear"
 }

--- a/packages/editor/src/i18n/en.json
+++ b/packages/editor/src/i18n/en.json
@@ -24,6 +24,7 @@
     "actions.copy": "Copy Markdown",
     "actions.share": "Share via URL",
     "more.title": "More options",
+    "menu.downloadMd": "Download (.md)",
     "menu.loadSample": "Load Sample",
     "menu.clearAll": "Clear All Contents",
     "menu.language": "Language",

--- a/packages/editor/src/i18n/en.json
+++ b/packages/editor/src/i18n/en.json
@@ -24,6 +24,7 @@
     "actions.copy": "Copy Markdown",
     "actions.share": "Share via URL",
     "more.title": "More options",
+    "menu.print": "Print",
     "menu.downloadMd": "Download (.md)",
     "menu.loadSample": "Load Sample",
     "menu.clearAll": "Clear All Contents",

--- a/packages/editor/src/i18n/ja.json
+++ b/packages/editor/src/i18n/ja.json
@@ -24,6 +24,7 @@
     "actions.copy": "Markdown をコピー",
     "actions.share": "URL で共有",
     "more.title": "その他の操作",
+    "menu.print": "印刷",
     "menu.downloadMd": "ダウンロード(.md)",
     "menu.loadSample": "サンプルを読み込み",
     "menu.clearAll": "すべての内容をクリア",

--- a/packages/editor/src/i18n/ja.json
+++ b/packages/editor/src/i18n/ja.json
@@ -28,5 +28,13 @@
     "menu.clearAll": "すべての内容をクリア",
     "menu.language": "言語",
     "menu.language.en": "英語",
-    "menu.language.ja": "日本語"
+    "menu.language.ja": "日本語",
+    "dialog.loadSample.title": "サンプルを読み込みますか？",
+    "dialog.loadSample.desc": "現在の内容はサンプルの内容で置き換えられます。実行するには『読み込み』を選択してください。",
+    "dialog.loadSample.cancel": "キャンセル",
+    "dialog.loadSample.load": "読み込み",
+    "dialog.clearAll.title": "すべての内容をクリアしますか？",
+    "dialog.clearAll.desc": "エディタの内容はすべて削除され、元に戻せません。実行するには『クリア』を選択してください。",
+    "dialog.clearAll.cancel": "キャンセル",
+    "dialog.clearAll.clear": "クリア"
 }

--- a/packages/editor/src/i18n/ja.json
+++ b/packages/editor/src/i18n/ja.json
@@ -24,6 +24,7 @@
     "actions.copy": "Markdown をコピー",
     "actions.share": "URL で共有",
     "more.title": "その他の操作",
+    "menu.downloadMd": "ダウンロード(.md)",
     "menu.loadSample": "サンプルを読み込み",
     "menu.clearAll": "すべての内容をクリア",
     "menu.language": "言語",

--- a/packages/editor/src/i18n/ja.json
+++ b/packages/editor/src/i18n/ja.json
@@ -25,7 +25,7 @@
     "actions.share": "URL で共有",
     "more.title": "その他の操作",
     "menu.print": "印刷",
-    "menu.downloadMd": "ダウンロード(.md)",
+    "menu.downloadMd": "ダウンロード（.md）",
     "menu.loadSample": "サンプルを読み込み",
     "menu.clearAll": "すべての内容をクリア",
     "menu.language": "言語",

--- a/packages/editor/src/utils/currency.ts
+++ b/packages/editor/src/utils/currency.ts
@@ -187,7 +187,8 @@ export const getCurrencyMinorUnit = (code: CurrencyCode, fallback: number = 2): 
 // Compact formatter: "20USD" without space/symbol, with configurable decimals (default 0)
 export const formatAmountCode = (amount: number, code: CurrencyCode, fractionDigits = 0): string => {
     try {
-        const n = typeof fractionDigits === 'number' ? Number(amount.toFixed(fractionDigits)) : amount;
+        const fd = typeof fractionDigits === 'number' ? Math.max(0, Math.min(20, fractionDigits)) : 0;
+        const n = Number(amount.toFixed(fd));
         return `${n.toLocaleString()}${String(code).toUpperCase()}`;
     } catch {
         return `${amount}${String(code).toUpperCase()}`;
@@ -197,7 +198,8 @@ export const formatAmountCode = (amount: number, code: CurrencyCode, fractionDig
 // Format as "12,345 CODE" with configurable fraction digits
 export const formatMoneyCodeSpaced = (amount: number, code: CurrencyCode, fractionDigits?: number): string => {
     try {
-        const digits = typeof fractionDigits === 'number' ? fractionDigits : getCurrencyMinorUnit(code, 2);
+        const inferred = typeof fractionDigits === 'number' ? fractionDigits : getCurrencyMinorUnit(code, 2);
+        const digits = Math.max(0, Math.min(20, inferred));
         const formatted = Number(amount).toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits });
         return `${formatted} ${String(code).toUpperCase()}`;
     } catch {

--- a/packages/editor/src/utils/download.ts
+++ b/packages/editor/src/utils/download.ts
@@ -1,0 +1,29 @@
+/**
+ * Utilities for client-side file download.
+ */
+
+export interface TriggerDownloadParams {
+    /** Raw data to download. Typically a string or Uint8Array */
+    data: string | Blob | ArrayBufferView;
+    /** Download file name, including extension */
+    fileName: string;
+    /** MIME type, defaults to text/plain */
+    mimeType?: string;
+}
+
+/**
+ * Trigger a browser download for the given data.
+ */
+export function triggerDownload(params: TriggerDownloadParams): void {
+    const { data, fileName, mimeType = 'text/plain;charset=utf-8' } = params;
+
+    const blob = data instanceof Blob ? data : new Blob([data as any], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+}

--- a/packages/editor/src/utils/download.ts
+++ b/packages/editor/src/utils/download.ts
@@ -25,5 +25,5 @@ export function triggerDownload(params: TriggerDownloadParams): void {
     document.body.appendChild(a);
     a.click();
     a.remove();
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/packages/editor/src/utils/print.ts
+++ b/packages/editor/src/utils/print.ts
@@ -1,0 +1,66 @@
+/**
+ * Utilities for printing the preview content in a separate window.
+ * The function opens a new window with collected styles and triggers print.
+ */
+
+export interface PrintOptions {
+    /** Title used in the print window */
+    title: string;
+    /** Preferred HTML container to render (e.g., preview element). If omitted, fallbackMarkdown is used. */
+    container?: HTMLElement | null;
+    /** Fallback raw Markdown text to render when container is not provided */
+    fallbackMarkdown?: string;
+}
+
+/**
+ * Open a new window for printing with the given content.
+ * Throws on errors; callers should handle user-facing notifications.
+ */
+export function openPrintWindow(options: PrintOptions): void {
+    const { title, container, fallbackMarkdown } = options;
+
+    // Collect existing stylesheet links (best effort)
+    const styleLinks: string[] = [];
+    const linkNodes = Array.from(document.querySelectorAll('link[rel="stylesheet"]')) as HTMLLinkElement[];
+    for (const ln of linkNodes) {
+        if (ln.href) styleLinks.push(ln.href);
+    }
+    const styleSheets = styleLinks.map((href) => `<link rel="stylesheet" href="${href}">`).join('\n');
+    const inlineStyleTags = Array.from(document.querySelectorAll('style'))
+        .map((el) => el.outerHTML)
+        .join('');
+
+    const extraStyle = `
+                <style>
+                @page { size: auto; margin: 12mm; }
+                html, body { background: white; }
+                .markdown-preview { padding: 0; }
+                .print-container { max-width: 210mm; margin: 0 auto; }
+                /* Avoid page break after headings */
+                h1, h2, h3 { break-after: avoid-page; page-break-after: avoid; }
+                /* Force page break before each day (with legacy property) */
+                .itmd-day { break-before: page; page-break-before: always; }
+                </style>
+            `;
+
+    const bodyInner = (() => {
+        if (container) return `<div class="print-container">${container.innerHTML}</div>`;
+        const raw = fallbackMarkdown || '';
+        const escaped = raw.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c] as string);
+        return `<pre>${escaped}</pre>`;
+    })();
+    const autoPrintScript = `<script>window.addEventListener('load', function(){ setTimeout(function(){ window.focus(); window.print(); }, 150); });</script>`;
+    const baseHref = document.baseURI || `${window.location.origin}/`;
+    const html = `<!doctype html><html><head><meta charset="utf-8"><base href="${baseHref}"><title>${title}</title>${styleSheets}${inlineStyleTags}${extraStyle}</head><body>${bodyInner}${autoPrintScript}</body></html>`;
+
+    const blob = new Blob([html], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const width = 960;
+    const height = 700;
+    const left = Math.max(0, Math.floor((window.screen.availWidth - width) / 2));
+    const top = Math.max(0, Math.floor((window.screen.availHeight - height) / 2));
+    const features = `noopener,scrollbars=yes,resizable=yes,toolbar=0,menubar=0,location=0,status=0,width=${width},height=${height},left=${left},top=${top}`;
+    window.open(url, 'tripmd-print', features);
+    // Clean up the blob URL after some delay
+    setTimeout(() => URL.revokeObjectURL(url), 60000);
+}

--- a/packages/editor/src/utils/url.ts
+++ b/packages/editor/src/utils/url.ts
@@ -27,3 +27,28 @@ export function isAllowedImageSrc(src?: string): boolean {
 export function buildGoogleMapsSearchUrl(location: string): string {
     return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`;
 }
+
+/**
+ * Make a safe file name from arbitrary input by removing reserved characters and trimming length.
+ * Allows Unicode letters and numbers (e.g. Japanese), spaces, dashes, underscores and dots.
+ * Replaces reserved/control characters with spaces, collapses whitespace, trims, and shortens.
+ */
+export function sanitizeFileName(input: string): string {
+    // Replace Windows-reserved characters with spaces
+    const withoutReserved = input.replace(/[\\/:*?"<>|]/g, ' ');
+    // Replace ASCII control chars (0x00-0x1F) with spaces
+    let withoutControl = '';
+    for (let i = 0; i < withoutReserved.length; i++) {
+        const ch = withoutReserved[i];
+        const code = ch.charCodeAt(0);
+        withoutControl += code < 32 ? ' ' : ch;
+    }
+    // Collapse whitespace
+    const collapsed = withoutControl.replace(/\s+/g, ' ').trim();
+    // Keep Unicode letters/numbers plus space, underscore, dash, and dot
+    const safe = collapsed.replace(/[^\p{L}\p{N} _.-]/gu, '');
+    // Avoid trailing dots/spaces which are problematic on Windows
+    const trimmed = safe.replace(/[. ]+$/u, '');
+    const base = trimmed || 'file';
+    return base.slice(0, 120);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - エディタに「印刷」と「Markdownダウンロード」を追加
  - @入力でIANAタイムゾーン補完を提供
  - プレビューでMDAST表示トグルとオートスクロール制御を移設

- 改善
  - 価格行で波括弧内の数式評価をサポート（計算結果を反映、警告表示）
  - 時刻表示に日付オフセットバッジを追加
  - 価格表示に換算表記と警告スタイルを追加
  - ファイル名サニタイズと印刷ダウンロードの安定化

- ドキュメント
  - 英日サンプルを別名表記、価格計算、アラート表記などで更新
  - スタジオ利用手順とリソース追記

- チョア
  - パッケージのマイナーバージョンおよび依存更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->